### PR TITLE
Add policyset generation support

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -60,6 +60,16 @@ policyDefaults:
   # annotation. This defaults to ["NIST SP 800-53"].
   standards:
     - "NIST SP 800-53"
+  # Optional. Array of policy sets that the policy will join. Policy set details can be defined
+  # in the policySets section. When a policy is part of a policy set, a placement binding will not be 
+  # generated for the policy since one is generated for the set. Set policies[*].generatePlacementWhenInSet 
+  # or policyDefaults.generatePlacementWhenInSet to override.
+  policySets: []
+  # Optional. When a policy is part of a policy set, by default the generator will not generate the placement
+  # for this policy since a placement is generated for the policy set. If a placement should still be generated, 
+  # set it to "true" so that the policy will be deployed with both policy placement and policy set placement. 
+  # This defaults to "false".
+  generatePlacementWhenInSet: false
 
 # Required. The list of policies to create along with overrides to either the default values or, if
 # set, the values given in policyDefaults.
@@ -125,3 +135,36 @@ policies:
     # Optional. (See policyDefaults.standards for description.)
     standards:
       - "NIST SP 800-53"
+    # Optional. (See policyDefaults.policySets for description.)
+    policySets: []
+    # Optional. (See policyDefaults.generatePlacementWhenInSet for description.)
+    generatePlacementWhenInSet: false
+
+# Optional. The list of policy sets to create. To include a policy in a policy set, use 
+# policies[*].policySets or policyDefaults.policySets or policySets.policies.
+policySets:
+    # Required. The name of the policy set to create.
+  - name: ""
+    # Optional. The description of the policy set to create.
+    description: ""
+    # Optional. The list of policies to be included in the policy set. If policies[*].policySets or 
+    # policyDefaults.policySets is also specified, the list is merged.
+    policies: []
+    # Optional. The placement configuration for the policy set. This defaults to a placement
+    # configuration that matches all clusters.
+    placement:
+      # To specify a placement rule, specify key:value pair cluster selectors. (See placementRulePath
+      # to specify an existing file instead.)
+      clusterSelectors: {}
+      # To specify a placement, specify key:value pair cluster label selectors. (See placementPath to
+      # specify an existing file instead.)
+      labelSelector: {}
+      # Optional. Specifying a name will consolidate placement rules that contain the same cluster
+      # selectors.
+      name: ""
+      # To reuse an existing placement manifest, specify the path here relative to the
+      # kustomization.yaml file. (See clusterSelectors to generate a new Placement instead.)
+      placementPath: ""
+      # To reuse an existing placement rule manifest, specify the path here relative to the
+      # kustomization.yaml file. (See clusterSelectors to generate a new PlacementRule instead.)
+      placementRulePath: ""

--- a/examples/policyGenerator.yaml
+++ b/examples/policyGenerator.yaml
@@ -20,6 +20,8 @@ policyDefaults:
   remediationAction: inform
   severity: medium
   # standards: []
+  policySets: 
+    - policyset-config
 policies:
 - name: policy-app-config-aliens
   disabled: false
@@ -48,6 +50,17 @@ policies:
   disabled: true
   manifests:
     - path: input-kyverno/
+  policySets:
+    - policyset-kyverno
 - name: policy-require-ns-labels
   manifests:
     - path: input-gatekeeper/
+  policySets:
+    - policyset-gatekeeper
+policySets:
+- name: policyset-kyverno
+  description: this is a kyverno policy set.
+  policies:
+    - pre-exists-kyverno-policy
+- name: policyset-gatekeeper
+  description: this is a gatekeeper policy set.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -31,14 +31,16 @@ type PolicyConfig struct {
 	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
 	// This is named Placement so that eventually PlacementRules and Placements will be supported
-	Placement                PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
-	RemediationAction        string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
-	Severity                 string          `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Standards                []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
-	ConsolidateManifests     bool            `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
-	Disabled                 bool            `json:"disabled,omitempty" yaml:"disabled,omitempty"`
-	InformGatekeeperPolicies bool            `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
-	InformKyvernoPolicies    bool            `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	Placement                  PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+	RemediationAction          string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
+	Severity                   string          `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Standards                  []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
+	ConsolidateManifests       bool            `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
+	Disabled                   bool            `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	InformGatekeeperPolicies   bool            `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
+	InformKyvernoPolicies      bool            `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	GeneratePlacementWhenInSet bool            `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
+	PolicySets                 []string        `json:"policySets,omitempty" yaml:"policySets,omitempty"`
 }
 
 type PolicyDefaults struct {
@@ -48,11 +50,21 @@ type PolicyDefaults struct {
 	Namespace         string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
 	// This is named Placement so that eventually PlacementRules and Placements will be supported
-	Placement                PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
-	RemediationAction        string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
-	Severity                 string          `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Standards                []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
-	ConsolidateManifests     bool            `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
-	InformGatekeeperPolicies bool            `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
-	InformKyvernoPolicies    bool            `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	Placement                  PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+	RemediationAction          string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
+	Severity                   string          `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Standards                  []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
+	ConsolidateManifests       bool            `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
+	InformGatekeeperPolicies   bool            `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
+	InformKyvernoPolicies      bool            `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	GeneratePlacementWhenInSet bool            `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
+	PolicySets                 []string        `json:"policySets,omitempty" yaml:"policySets,omitempty"`
+}
+
+type PolicySetConfig struct {
+	Name        string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Policies    []string `json:"policies,omitempty" yaml:"policies,omitempty"`
+	// This is named Placement so that eventually PlacementRules and Placements will be supported
+	Placement PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
 }


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/19412
Implement logic to generate policysets. There are three ways to generate
1. use policyDefaults.policysets field. If specified, any policies
without override will be included in the policysets
2. use policies[*].policysets field to include current policy in the
policysets. If specified, it overrides the policyDefaults.policysets
3. use policysets field. This allows you specify any policies no matter
policies are generated by generator or pre-exsit on hub. This field also
allows you specify the description of the policyset.

Signed-off-by: Yu Cao <ycao@redhat.com>