### PR TITLE
Ensure policyset name is unique

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -482,7 +482,7 @@ func (p *Plugin) assertValidConfig() error {
 		return errors.New("policies is empty but it must be set")
 	}
 
-	seen := map[string]bool{}
+	seenPlc := map[string]bool{}
 	plCount := struct {
 		plc int
 		plr int
@@ -495,12 +495,12 @@ func (p *Plugin) assertValidConfig() error {
 			)
 		}
 
-		if seen[policy.Name] {
+		if seenPlc[policy.Name] {
 			return fmt.Errorf(
 				"each policy must have a unique name set, but found a duplicate name: %s", policy.Name,
 			)
 		}
-		seen[policy.Name] = true
+		seenPlc[policy.Name] = true
 
 		if len(p.PolicyDefaults.Namespace+"."+policy.Name) > maxObjectNameLength {
 			return fmt.Errorf("the policy namespace and name cannot be more than 63 characters: %s.%s",
@@ -587,8 +587,8 @@ func (p *Plugin) assertValidConfig() error {
 		}
 	}
 
+	seenPlcset := map[string]bool{}
 	for i := range p.PolicySets {
-		seen := map[string]bool{}
 		plcset := &p.PolicySets[i]
 
 		if plcset.Name == "" {
@@ -597,12 +597,12 @@ func (p *Plugin) assertValidConfig() error {
 			)
 		}
 
-		if seen[plcset.Name] {
+		if seenPlcset[plcset.Name] {
 			return fmt.Errorf(
 				"each policySet must have a unique name set, but found a duplicate name: %s", plcset.Name,
 			)
 		}
-		seen[plcset.Name] = true
+		seenPlcset[plcset.Name] = true
 
 		// Validate policy Placement settings
 		if plcset.Placement.PlacementRulePath != "" && plcset.Placement.PlacementPath != "" {
@@ -660,7 +660,7 @@ func (p *Plugin) assertValidConfig() error {
 	// Validate only one type of placement kind is in use
 	if plCount.plc != 0 && plCount.plr != 0 {
 		return fmt.Errorf(
-			"may not use a mix of Placement and PlacementRule for policies; found %d Placement and %d PlacementRule",
+			"may not use a mix of Placement and PlacementRule for policies and policysets; found %d Placement and %d PlacementRule",
 			plCount.plc, plCount.plr,
 		)
 	}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -14,9 +14,10 @@ import (
 
 type testCase struct {
 	name                            string
-	setupFunc                       func(p *Plugin, policyConf types.PolicyConfig, policyConf2 types.PolicyConfig)
+	setupFunc                       func(p *Plugin)
 	expectedPolicySetConfigInPolicy [][]string
 	expectedPolicySetConfigs        []types.PolicySetConfig
+	expectedErrMsg                  string
 }
 
 func TestGenerate(t *testing.T) {
@@ -1170,7 +1171,7 @@ func TestGeneratePolicySets(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "Use p.PolicyDefaults.PolicySets only",
-			setupFunc: func(p *Plugin, policyConf types.PolicyConfig, policyConf2 types.PolicyConfig) {
+			setupFunc: func(p *Plugin) {
 				// PolicyDefaults.PolicySets should be applied to both policies
 				p.PolicyDefaults.PolicySets = []string{"policyset-default"}
 			},
@@ -1190,7 +1191,7 @@ func TestGeneratePolicySets(t *testing.T) {
 		},
 		{
 			name: "Use p.Policies[0].PolicySets to override with a different policy set",
-			setupFunc: func(p *Plugin, policyConf types.PolicyConfig, policyConf2 types.PolicyConfig) {
+			setupFunc: func(p *Plugin) {
 				// p.PolicyDefaults.PolicySets should be overridden by p.Policies[0].PolicySets
 				p.PolicyDefaults.PolicySets = []string{"policyset-default"}
 				p.Policies[0] = types.PolicyConfig{
@@ -1224,7 +1225,7 @@ func TestGeneratePolicySets(t *testing.T) {
 		},
 		{
 			name: "Use p.Policies[0].PolicySets to override with an empty policyset",
-			setupFunc: func(p *Plugin, policyConf types.PolicyConfig, policyConf2 types.PolicyConfig) {
+			setupFunc: func(p *Plugin) {
 				// p.PolicyDefaults.PolicySets should be overridden by p.Policies[0].PolicySets
 				p.PolicyDefaults.PolicySets = []string{"policyset-default"}
 				p.Policies[0] = types.PolicyConfig{
@@ -1252,7 +1253,7 @@ func TestGeneratePolicySets(t *testing.T) {
 		},
 		{
 			name: "Use p.Policies[0].PolicySets and p.PolicySets, should merge",
-			setupFunc: func(p *Plugin, policyConf types.PolicyConfig, policyConf2 types.PolicyConfig) {
+			setupFunc: func(p *Plugin) {
 				// p.Policies[0].PolicySets and p.PolicySets should merge
 				p.PolicySets = []types.PolicySetConfig{
 					{
@@ -1311,7 +1312,7 @@ func TestGeneratePolicySets(t *testing.T) {
 				},
 			}
 			p.Policies = append(p.Policies, policyConf, policyConf2)
-			tc.setupFunc(&p, policyConf, policyConf2)
+			tc.setupFunc(&p)
 			p.applyDefaults(map[string]interface{}{})
 			assertReflectEqual(t, p.Policies[0].PolicySets, tc.expectedPolicySetConfigInPolicy[0])
 			assertReflectEqual(t, p.Policies[1].PolicySets, tc.expectedPolicySetConfigInPolicy[1])


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/19644
Fix the issue that policyset name could be duplicated.
Add test cases for policyset config validation.

Signed-off-by: Yu Cao <ycao@redhat.com>