### PR TITLE
Rename the module name to match upstream

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,7 @@ import (
 	"path"
 
 	"github.com/spf13/pflag"
-	"github.com/stolostron/policy-generator-plugin/internal"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal"
 )
 
 var debug = false

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stolostron/policy-generator-plugin
+module open-cluster-management.io/ocm-kustomize-generator-plugins
 
 go 1.17
 

--- a/internal/expanders/expanders.go
+++ b/internal/expanders/expanders.go
@@ -2,7 +2,7 @@
 package expanders
 
 import (
-	"github.com/stolostron/policy-generator-plugin/internal/types"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 // GetExpanders returns the list of available expanders.

--- a/internal/expanders/gatekeeper.go
+++ b/internal/expanders/gatekeeper.go
@@ -4,8 +4,8 @@ package expanders
 import (
 	"fmt"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type GatekeeperPolicyExpander struct{}

--- a/internal/expanders/gatekeeper_test.go
+++ b/internal/expanders/gatekeeper_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 func TestGatekeeperCanHandle(t *testing.T) {

--- a/internal/expanders/kyverno.go
+++ b/internal/expanders/kyverno.go
@@ -4,8 +4,8 @@ package expanders
 import (
 	"fmt"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type KyvernoPolicyExpander struct{}

--- a/internal/expanders/kyverno_test.go
+++ b/internal/expanders/kyverno_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 func TestKyvernoCanHandle(t *testing.T) {

--- a/internal/patches.go
+++ b/internal/patches.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/kyaml/filesys"

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 const (

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 func createConfigMap(t *testing.T, tmpDir, filename string) {

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 type testCase struct {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -12,10 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/stolostron/policy-generator-plugin/internal/expanders"
-	"github.com/stolostron/policy-generator-plugin/internal/types"
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/expanders"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 // getManifests will get all of the manifest files associated with the input policy configuration

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stolostron/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {


### PR DESCRIPTION
This will significantly reduce merge conflicts when syncing upstream to
Stolostron. It will also reduce the overhead of maintaining the
difference.

This also fixes some linting errors.

Related:
https://github.com/stolostron/backlog/issues/21790