### PR TITLE
Add ability to specify the name of an existing Placement or PlacementRule

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -65,6 +65,18 @@ policyDefaults:
     # kustomization.yaml file. If given, this placement rule will be used by all policies by
     # default. (See clusterSelectors to generate a new PlacementRule instead.)
     placementRulePath: ""
+    # Use a placement that already exists in the cluster in the same namespace as the policy to be
+    # generated. It is the responsibility of the administrator to ensure the placement exists. Use
+    # of this setting will prevent a Placement from being generated, but the Placement Binding will
+    # still be created.
+    placementName: ""
+    # Use a placement rule that already exists in the cluster in the same namespace as the policy to
+    # be generated. It is the responsibility of the administrator to ensure the placement rule
+    # exists. Use of this setting will prevent a placement rule from being generated, but the
+    # placement binding will still be created.
+    placementRuleName: ""
+
+
   # Optional. The remediation action ("inform" or "enforce") for each configuration policy. This
   # defaults to "inform".
   remediationAction: "inform"

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -387,8 +387,41 @@ policies:
 		t.Fatal("Expected an error but did not get one")
 	}
 
-	expected := "policy policy-app-config may not specify a placement selector and " +
-		"placement path together"
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigMultiplePlacementsClusterSelectorAndPlRName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+policies:
+- name: policy-app-config
+  placement:
+    clusterSelectors:
+      cloud: red hat
+    placementRuleName: plrExistingName
+  manifests:
+    - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
 	assertEqual(t, err.Error(), expected)
 }
 
@@ -420,8 +453,41 @@ policies:
 		t.Fatal("Expected an error but did not get one")
 	}
 
-	expected := "policy policy-app-config may not specify a placement selector and " +
-		"placement path together"
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigMultiplePlacementsLabelSelectorAndPlRName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+policies:
+- name: policy-app-config
+  placement:
+    labelSelector:
+      cloud: red hat
+    placementRuleName: plrExistingName
+  manifests:
+    - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
 	assertEqual(t, err.Error(), expected)
 }
 
@@ -453,8 +519,41 @@ policies:
 		t.Fatal("Expected an error but did not get one")
 	}
 
-	expected := "policy policy-app-config may not specify a placement selector and " +
-		"placement path together"
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigMultiplePlacementsLabelSelectorAndPlName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+policies:
+- name: policy-app-config
+  placement:
+    labelSelector:
+      cloud: red hat
+    placementName: plExistingName
+  manifests:
+    - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
 	assertEqual(t, err.Error(), expected)
 }
 
@@ -554,6 +653,38 @@ policies:
 	assertEqual(t, err.Error(), expected)
 }
 
+func TestConfigMultipleDefaultPlacementName(t *testing.T) {
+	t.Parallel()
+	const config = `
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+  placement:
+    placementName: plExistingName
+    placementRuleName: plrExistingName
+policies:
+- name: policy-app-config
+  placement:
+    clusterSelectors:
+      cloud: red hat
+    placementRuleName: plrExistingName
+  manifests:
+    - path: input/configmap.yaml
+`
+	p := Plugin{}
+	err := p.Config([]byte(config), "")
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policyDefaults must provide only one of " +
+		"placement.placementName or placement.placementRuleName"
+	assertEqual(t, err.Error(), expected)
+}
+
 func TestConfigMultipleDefaultAndPolicyPlacements(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -583,8 +714,42 @@ policies:
 		t.Fatal("Expected an error but did not get one")
 	}
 
-	expected := "policy policy-app-config may not specify a " +
-		"placement selector and placement path together"
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigMultipleDefaultAndPolicyPlacementNames(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+  placement:
+    placementName: plExistingName
+policies:
+- name: policy-app-config
+  placement:
+    clusterSelectors:
+      cloud: red hat
+  manifests:
+  - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policy policy-app-config must specify only one of " +
+		"placement selector, placement path, or placement name"
 	assertEqual(t, err.Error(), expected)
 }
 
@@ -968,6 +1133,21 @@ func TestPolicySetConfig(t *testing.T) {
 			expectedErrMsg: "policySet my-policyset must provide only one of placementRulePath or placementPath",
 		},
 		{
+			name: "policySet must provide only one of placementRuleName or placementName",
+			setupFunc: func(p *Plugin) {
+				p.PolicySets = []types.PolicySetConfig{
+					{
+						Name: "my-policyset",
+						Placement: types.PlacementConfig{
+							PlacementName:     "plExistingName",
+							PlacementRuleName: "plrExistingName",
+						},
+					},
+				}
+			},
+			expectedErrMsg: "policySet my-policyset must provide only one of placementRuleName or placementName",
+		},
+		{
 			name: "policySet must provide only one of labelSelector or clusterselectors",
 			setupFunc: func(p *Plugin) {
 				p.PolicySets = []types.PolicySetConfig{
@@ -995,7 +1175,22 @@ func TestPolicySetConfig(t *testing.T) {
 					},
 				}
 			},
-			expectedErrMsg: "policySet my-policyset may not specify a placement selector and placement path together",
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
+		},
+		{
+			name: "policySet may not specify a cluster selector and placement name together",
+			setupFunc: func(p *Plugin) {
+				p.PolicySets = []types.PolicySetConfig{
+					{
+						Name: "my-policyset",
+						Placement: types.PlacementConfig{
+							PlacementName:    "plExistingName",
+							ClusterSelectors: map[string]string{"cloud": "red hat"},
+						},
+					},
+				}
+			},
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
 		},
 		{
 			name: "policySet may not specify a label selector and placement path together",
@@ -1010,7 +1205,22 @@ func TestPolicySetConfig(t *testing.T) {
 					},
 				}
 			},
-			expectedErrMsg: "policySet my-policyset may not specify a placement selector and placement path together",
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
+		},
+		{
+			name: "policySet may not specify a label selector and placement name together",
+			setupFunc: func(p *Plugin) {
+				p.PolicySets = []types.PolicySetConfig{
+					{
+						Name: "my-policyset",
+						Placement: types.PlacementConfig{
+							PlacementName: "plExistingName",
+							LabelSelector: map[string]string{"cloud": "red hat"},
+						},
+					},
+				}
+			},
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
 		},
 		{
 			name: "policySet may not specify a cluster selector and placementrule path together",
@@ -1025,7 +1235,22 @@ func TestPolicySetConfig(t *testing.T) {
 					},
 				}
 			},
-			expectedErrMsg: "policySet my-policyset may not specify a placement selector and placement path together",
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
+		},
+		{
+			name: "policySet may not specify a cluster selector and placementrule name together",
+			setupFunc: func(p *Plugin) {
+				p.PolicySets = []types.PolicySetConfig{
+					{
+						Name: "my-policyset",
+						Placement: types.PlacementConfig{
+							PlacementRuleName: "plrExisingName",
+							ClusterSelectors:  map[string]string{"cloud": "red hat"},
+						},
+					},
+				}
+			},
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
 		},
 		{
 			name: "policySet may not specify a label selector and placementrule path together",
@@ -1040,7 +1265,22 @@ func TestPolicySetConfig(t *testing.T) {
 					},
 				}
 			},
-			expectedErrMsg: "policySet my-policyset may not specify a placement selector and placement path together",
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
+		},
+		{
+			name: "policySet may not specify a label selector and placementrule name together",
+			setupFunc: func(p *Plugin) {
+				p.PolicySets = []types.PolicySetConfig{
+					{
+						Name: "my-policyset",
+						Placement: types.PlacementConfig{
+							PlacementRuleName: "plrExisingName",
+							LabelSelector:     map[string]string{"cloud": "red hat"},
+						},
+					},
+				}
+			},
+			expectedErrMsg: "policySet my-policyset must specify only one of placement selector, placement path, or placement name",
 		},
 		{
 			name: "policySet placementrule path not resolvable",

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -173,6 +173,178 @@ subjects:
 	assertEqual(t, string(output), expected)
 }
 
+func TestGeneratePolicyExisingPlacementRuleName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	p := Plugin{}
+	var err error
+	p.baseDirectory, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	p.PolicyDefaults.Placement.PlacementRuleName = "plrExistingName"
+	p.PolicyDefaults.Namespace = "my-policies"
+	p.PolicyDefaults.MetadataComplianceType = "musthave"
+	policyConf := types.PolicyConfig{
+		Name: "policy-app-config",
+		Manifests: []types.Manifest{
+			{
+				Path: path.Join(tmpDir, "configmap.yaml"),
+			},
+		},
+	}
+	p.Policies = append(p.Policies, policyConf)
+	p.applyDefaults(map[string]interface{}{})
+	// Default all policy ConsolidateManifests flags are set to true
+	// unless explicitly set
+	assertEqual(t, p.Policies[0].ConsolidateManifests, true)
+	if err := p.assertValidConfig(); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expected := `
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: policy-app-config
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: policy-app-config
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-policy-app-config
+    namespace: my-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: plrExistingName
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: policy-app-config
+`
+	expected = strings.TrimPrefix(expected, "\n")
+	output, err := p.Generate()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	assertEqual(t, string(output), expected)
+}
+
+func TestGeneratePolicyExisingPlacementName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	p := Plugin{}
+	var err error
+	p.baseDirectory, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	p.PolicyDefaults.Placement.PlacementName = "plExistingName"
+	p.PolicyDefaults.Namespace = "my-policies"
+	p.PolicyDefaults.MetadataComplianceType = "musthave"
+	policyConf := types.PolicyConfig{
+		Name: "policy-app-config",
+		Manifests: []types.Manifest{
+			{
+				Path: path.Join(tmpDir, "configmap.yaml"),
+			},
+		},
+	}
+	p.Policies = append(p.Policies, policyConf)
+	p.applyDefaults(map[string]interface{}{})
+	// Default all policy ConsolidateManifests flags are set to true
+	// unless explicitly set
+	assertEqual(t, p.Policies[0].ConsolidateManifests, true)
+	if err := p.assertValidConfig(); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expected := `
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: policy-app-config
+    namespace: my-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: policy-app-config
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            game.properties: enemies=potato
+                        kind: ConfigMap
+                        metadata:
+                            name: my-configmap
+                remediationAction: inform
+                severity: low
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-policy-app-config
+    namespace: my-policies
+placementRef:
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
+    name: plExistingName
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: policy-app-config
+`
+	expected = strings.TrimPrefix(expected, "\n")
+	output, err := p.Generate()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	assertEqual(t, string(output), expected)
+}
+
 func TestGenerateSeparateBindings(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,6 +20,8 @@ type PlacementConfig struct {
 	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
 	PlacementPath     string            `json:"placementPath,omitempty" yaml:"placementPath,omitempty"`
 	PlacementRulePath string            `json:"placementRulePath,omitempty" yaml:"placementRulePath,omitempty"`
+	PlacementName     string            `json:"placementName,omitempty" yaml:"placementName,omitempty"`
+	PlacementRuleName string            `json:"placementRuleName,omitempty" yaml:"placementRuleName,omitempty"`
 }
 
 type EvaluationInterval struct {


### PR DESCRIPTION
This allows managing all Placements/PlacementRules in the ACM hub separate from the generated policies that use them.

Fixes #50 

Example usage available at https://github.com/brian-jarvis/test-placement/tree/reuse-placement

Signed-off-by: Brian Jarvis <bjarvis@redhat.com>