### PR TITLE
Fail generation and add help on field typos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module open-cluster-management.io/ocm-kustomize-generator-plugins
 go 1.18
 
 require (
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.23.3
@@ -32,7 +33,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20220213143740-c55a923347b1 // indirect

--- a/internal/typohelper.go
+++ b/internal/typohelper.go
@@ -1,0 +1,118 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// addFieldNotFoundHelp adds help text to errors that occur when the input config
+// has a field that is not present in the Config struct (eg a typo), to assist
+// the user in debugging the problem. If the input error was not from a missing
+// field, then it is returned unchanged.
+func addFieldNotFoundHelp(err error) error {
+	re := regexp.MustCompile(`field (\S*) not found in type (\S*)`)
+
+	repl := func(line string) string {
+		match := re.FindStringSubmatch(line)
+
+		fieldType := reflect.TypeOf(Plugin{})
+		fieldTag := "PolicyGenerator"
+
+		if match[2] != fieldType.String() {
+			// Search the right type, if it's not the top-level object.
+			fieldType, fieldTag = findNestedType(fieldType, match[2], "")
+		}
+
+		msg := fmt.Sprintf("field %v found but not defined", match[1])
+
+		if fieldTag != "" {
+			msg += fmt.Sprintf(" in type %v", fieldTag)
+		}
+
+		suggestion := autocorrectField(match[1], fieldType)
+		if suggestion != "" {
+			msg += fmt.Sprintf(" - did you mean '%v'?", suggestion)
+		}
+
+		return msg
+	}
+
+	helpMsg := re.ReplaceAllStringFunc(err.Error(), repl)
+
+	if helpMsg == err.Error() {
+		// Error was unchanged, return the original to preserve the type
+		return err
+	}
+
+	return errors.New(helpMsg)
+}
+
+// autocorrectField returns the field in the containingType which most closely
+// matches the input badField. It will return an empty string if no match can
+// be found with sufficient confidence.
+func autocorrectField(badField string, containingType reflect.Type) string {
+	if containingType == nil || containingType.Kind() != reflect.Struct {
+		return ""
+	}
+
+	matcher := difflib.NewMatcher(strings.Split(badField, ""), []string{""})
+	bestRatio := 0.85 // require 85% or better match
+	bestMatch := ""
+
+	// iterate over all fields in the struct that have a yaml tag.
+	for _, field := range reflect.VisibleFields(containingType) {
+		yamlTag := strings.SplitN(field.Tag.Get("yaml"), ",", 2)[0]
+		if yamlTag == "" {
+			continue
+		}
+
+		matcher.SetSeq2(strings.Split(yamlTag, ""))
+
+		ratio := matcher.Ratio()
+		if ratio > bestRatio {
+			bestRatio = ratio
+			bestMatch = yamlTag
+		}
+	}
+
+	return bestMatch
+}
+
+// findNestedType searches through the given type and nested types (recursively)
+// for a type matching the wanted string. It will return the matching type if
+// found, or nil if not found. It will also return the yaml tag of the field
+// where the type was found.
+func findNestedType(baseType reflect.Type, want string, tag string) (reflect.Type, string) {
+	if baseType.String() == want {
+		return baseType, tag
+	}
+
+	if baseType.Kind() == reflect.Array || baseType.Kind() == reflect.Slice || baseType.Kind() == reflect.Map {
+		return findNestedType(baseType.Elem(), want, tag)
+	}
+
+	if baseType.Kind() != reflect.Struct {
+		return nil, ""
+	}
+
+	// iterate over all fields in the struct that have a yaml tag.
+	for _, field := range reflect.VisibleFields(baseType) {
+		yamlTag := strings.SplitN(field.Tag.Get("yaml"), ",", 2)[0]
+
+		if field.Type.String() == want {
+			return field.Type, yamlTag
+		}
+
+		deeperType, deeperTag := findNestedType(field.Type, want, yamlTag)
+		if deeperType != nil {
+			return deeperType, deeperTag
+		}
+	}
+
+	return nil, ""
+}

--- a/internal/typohelper_test.go
+++ b/internal/typohelper_test.go
@@ -1,0 +1,170 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"regexp"
+	"testing"
+)
+
+func TestConfigTypos(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+
+	suggestFmt := "line %v: field %v found but not defined in type %v - did you mean '%v'?"
+
+	tests := map[string]struct {
+		desiredErrs []string
+		generator   []byte
+	}{
+		"no typos": {
+			desiredErrs: []string{},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefaults:
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - path: @@@
+`),
+		},
+		"one typo with suggestion": {
+			desiredErrs: []string{
+				fmt.Sprintf(suggestFmt, "6", "policyDefault", "PolicyGenerator", "policyDefaults"),
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefault:
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - path: @@@
+`),
+		},
+		"two typos with suggestions": {
+			desiredErrs: []string{
+				fmt.Sprintf(suggestFmt, "6", "policyDefault", "PolicyGenerator", "policyDefaults"),
+				fmt.Sprintf(suggestFmt, "8", "policie", "PolicyGenerator", "policies"),
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefault:
+  namespace: minimal
+policie:
+- name: my-minimal
+  manifests:
+  - path: @@@
+`),
+		},
+		"one deeper typo": {
+			desiredErrs: []string{
+				fmt.Sprintf(suggestFmt, "7", "configPolicyAnnotations", "policyDefaults",
+					"configurationPolicyAnnotations"),
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefaults:
+  configPolicyAnnotations: {}
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - path: @@@
+`),
+		},
+		"typo inside a list": {
+			desiredErrs: []string{
+				fmt.Sprintf(suggestFmt, "11", "paths", "manifests", "path"),
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefaults:
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - paths: @@@
+`),
+		},
+		"typo no suggestion": {
+			desiredErrs: []string{
+				"line 12: field namespace found but not defined in type manifests$",
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-minimal
+policyDefaults:
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - path: @@@
+    namespace: foo
+`),
+		},
+		"non-typo error": {
+			desiredErrs: []string{
+				"line 6: cannot unmarshal !!seq into string",
+			},
+			generator: []byte(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: 
+  - policy-generator-minimal
+policyDefaults:
+  namespace: minimal
+policies:
+- name: my-minimal
+  manifests:
+  - path: @@@
+`),
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := Plugin{}
+			generatorYaml := bytes.ReplaceAll(
+				test.generator,
+				[]byte(`@@@`),
+				[]byte(path.Join(tmpDir, "configmap.yaml")))
+
+			err := p.Config(generatorYaml, tmpDir)
+			if err == nil && len(test.desiredErrs) > 0 {
+				t.Fatal("Expected an error to be emitted, got nil")
+			}
+
+			for _, want := range test.desiredErrs {
+				if match, _ := regexp.MatchString(want, err.Error()); !match {
+					t.Errorf("Expected error to include '%v' - got '%v'", want, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the input configuration does not match the schema in the go type,
the generator will now respond with an error. The intention is to help
users when there is a typo in the configuration, which otherwise would
just be ignored (and in the case of a map, any configuration "inside"
would be dropped).

This also adds help text to these error cases, to try and identify what
field the user might have meant. That implementation uses a library
which does not compute the Levenshtein distance, but should work well
enough, and has the advantage of already being in the import graph.

Refs:
 - https://github.com/stolostron/backlog/issues/19646

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>