### PR TITLE
Support `PruneObjectBehavior`

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -43,6 +43,10 @@ policyDefaults:
     # avoid evaluating the policy after it has become a particular compliance state.
     compliant: 30m
     noncompliant: 45s
+  # Optional. Determines whether objects created or monitored by the policy should be deleted when the policy is
+  # deleted. Pruning only takes place if the remediation action of the policy has been set to "enforce". Example values
+  # are "DeleteIfCreated", "DeleteAll", or "None". This defaults to unset, which is equivalent to "None".
+  pruneObjectBehavior: "None"
   # Optional. When the policy references a Kyverno policy manifest, this determines if an additional
   # configuration policy should be generated in order to receive policy violations in Open Cluster
   # Management when the Kyverno policy has been violated. This defaults to true.
@@ -138,6 +142,8 @@ policies:
         metadataComplianceType: ""
          # Optional. (See policyDefaults.evaluationInterval for description.)
         evaluationInterval: {}
+        # Optional. (See policyDefaults.pruneObjectBehavior for description.)
+        pruneObjectBehavior: ""
         # (Note: a path to a directory containing a Kustomize manifest is a supported alternative.) Optional. A
         # Kustomize patch to apply to the manifest(s) at the path. If there are multiple manifests, the patch requires
         # the apiVersion, kind, metadata.name, and metadata.namespace (if applicable) fields to be set so Kustomize can
@@ -174,6 +180,8 @@ policies:
     disabled: false
     # Optional. (See policyDefaults.evaluationInterval for description.)
     evaluationInterval: {}
+    # Optional. (See policyDefaults.pruneObjectBehavior for description.)
+    pruneObjectBehavior: ""
     # Optional. (See policyDefaults.informKyvernoPolicies for description.)
     informKyvernoPolicies: true
     # Optional. (See policyDefaults.consolidateManifests for description.)

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -463,6 +463,10 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			}
 		}
 
+		if policy.PruneObjectBehavior == "" {
+			policy.PruneObjectBehavior = p.PolicyDefaults.PruneObjectBehavior
+		}
+
 		if policy.PolicySets == nil {
 			policy.PolicySets = p.PolicyDefaults.PolicySets
 		}
@@ -588,6 +592,10 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 				if !set {
 					manifest.EvaluationInterval.NonCompliant = policy.EvaluationInterval.NonCompliant
 				}
+			}
+
+			if manifest.PruneObjectBehavior == "" && policy.PruneObjectBehavior != "" {
+				manifest.PruneObjectBehavior = policy.PruneObjectBehavior
 			}
 		}
 
@@ -791,6 +799,17 @@ func (p *Plugin) assertValidConfig() error {
 			err = verifyManifestPath(p.baseDirectory, manifest.Path)
 			if err != nil {
 				return err
+			}
+
+			// Verify that consolidated manifests don't specify fields
+			// that can't be overridden at the objectTemplate level
+			if policy.ConsolidateManifests && manifest.PruneObjectBehavior != "" {
+				return fmt.Errorf(
+					"the policy %s has the pruneObjectBehavior value set on manifest[%d] but "+
+						"consolidateManifests is true",
+					policy.Name,
+					j,
+				)
 			}
 
 			evalInterval := &manifest.EvaluationInterval

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -39,6 +39,7 @@ func TestGenerate(t *testing.T) {
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"
 	p.PolicyDefaults.MetadataComplianceType = "musthave"
+	p.PolicyDefaults.PruneObjectBehavior = "DeleteAll"
 	patch := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{
@@ -47,7 +48,8 @@ func TestGenerate(t *testing.T) {
 		},
 	}
 	policyConf := types.PolicyConfig{
-		Name: "policy-app-config",
+		Name:                "policy-app-config",
+		PruneObjectBehavior: "None",
 		Manifests: []types.Manifest{
 			{
 				Path:    path.Join(tmpDir, "configmap.yaml"),
@@ -107,6 +109,7 @@ spec:
                             labels:
                                 chandler: bing
                             name: my-configmap
+                pruneObjectBehavior: None
                 remediationAction: inform
                 severity: low
 ---
@@ -138,6 +141,7 @@ spec:
                         kind: ConfigMap
                         metadata:
                             name: my-configmap
+                pruneObjectBehavior: DeleteAll
                 remediationAction: inform
                 severity: low
 ---

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -11,6 +11,7 @@ type Manifest struct {
 	ComplianceType         string                   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
 	MetadataComplianceType string                   `json:"metadataComplianceType,omitempty" yaml:"metadataComplianceType,omitempty"`
 	EvaluationInterval     EvaluationInterval       `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
+	PruneObjectBehavior    string                   `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
 	Patches                []map[string]interface{} `json:"patches,omitempty" yaml:"patches,omitempty"`
 	Path                   string                   `json:"path,omitempty" yaml:"path,omitempty"`
 }
@@ -80,6 +81,7 @@ type PolicyConfig struct {
 	EvaluationInterval             EvaluationInterval `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
 	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
 	ConfigurationPolicyAnnotations map[string]string  `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
+	PruneObjectBehavior            string             `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
 }
 
 type PolicyDefaults struct {
@@ -103,6 +105,7 @@ type PolicyDefaults struct {
 	EvaluationInterval             EvaluationInterval `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
 	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
 	ConfigurationPolicyAnnotations map[string]string  `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
+	PruneObjectBehavior            string             `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
 }
 
 type PolicySetConfig struct {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1338,7 +1338,7 @@ func TestProcessKustomizeDir(t *testing.T) {
 		"kustomization.yaml": `
 resources:
 - configmap.yaml
-- https://github.com/dhaiducek/policy-generator-plugin/examples/input-kustomize/?ref=support-kustomize
+- https://github.com/dhaiducek/policy-generator-plugin/examples/input-kustomize/?ref=kustomize-dir
 
 namespace: kustomize-test
 `,

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1338,7 +1338,7 @@ func TestProcessKustomizeDir(t *testing.T) {
 		"kustomization.yaml": `
 resources:
 - configmap.yaml
-- https://github.com/dhaiducek/policy-generator-plugin/examples/input-kustomize/?ref=kustomize-dir
+- https://github.com/stolostron/policy-generator-plugin/examples/input-kustomize/?ref=main
 
 namespace: kustomize-test
 `,


### PR DESCRIPTION
I was uncertain whether the value should be validated. I didn't validate it since other string fields in the generator (like `complianceType` and `remediationAction`) didn't appear to have validation in place.

Addresses:
- https://github.com/stolostron/backlog/issues/25353
