### PR TITLE
Consolidate structs / Consistent `manifests` overrides

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -144,10 +144,21 @@ policies:
         complianceType: "musthave"
         # Optional. (See policyDefaults.metadataComplianceType for description.)
         metadataComplianceType: ""
+        # Optional. (See policyDefaults.namespaceSelector for description.)
+        # Cannot be specified when policyDefaults.consolidateManifests is set to true.
+        namespaceSelector: {}
          # Optional. (See policyDefaults.evaluationInterval for description.)
+        # Cannot be specified when policyDefaults.consolidateManifests is set to true.
         evaluationInterval: {}
         # Optional. (See policyDefaults.pruneObjectBehavior for description.)
+        # Cannot be specified when policyDefaults.consolidateManifests is set to true.
         pruneObjectBehavior: ""
+        # Optional. (See policyDefaults.remediationAction for description.)
+        # Cannot be specified when policyDefaults.consolidateManifests is set to true.
+        remediationAction: ""
+        # Optional. (See policyDefaults.severity for description.)
+        # Cannot be specified when policyDefaults.consolidateManifests is set to true.
+        severity: "low"
         # (Note: a path to a directory containing a Kustomize manifest is a supported alternative.) Optional. A
         # Kustomize patch to apply to the manifest(s) at the path. If there are multiple manifests, the patch requires
         # the apiVersion, kind, metadata.name, and metadata.namespace (if applicable) fields to be set so Kustomize can

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -47,6 +47,10 @@ policyDefaults:
   # deleted. Pruning only takes place if the remediation action of the policy has been set to "enforce". Example values
   # are "DeleteIfCreated", "DeleteAll", or "None". This defaults to unset, which is equivalent to "None".
   pruneObjectBehavior: "None"
+  # Optional. When the policy references a Gatekeeper policy manifest, this determines if an additional
+  # configuration policy should be generated in order to receive policy violations in Open Cluster
+  # Management when the Gatekeeper policy has been violated. This defaults to true.
+  informGatekeeperPolicies: true
   # Optional. When the policy references a Kyverno policy manifest, this determines if an additional
   # configuration policy should be generated in order to receive policy violations in Open Cluster
   # Management when the Kyverno policy has been violated. This defaults to true.
@@ -182,6 +186,8 @@ policies:
     evaluationInterval: {}
     # Optional. (See policyDefaults.pruneObjectBehavior for description.)
     pruneObjectBehavior: ""
+    # Optional. (See policyDefaults.informGatekeeperPolicies for description.)
+    informGatekeeperPolicies: true
     # Optional. (See policyDefaults.informKyvernoPolicies for description.)
     informKyvernoPolicies: true
     # Optional. (See policyDefaults.consolidateManifests for description.)

--- a/internal/expanders/gatekeeper_test.go
+++ b/internal/expanders/gatekeeper_test.go
@@ -74,7 +74,8 @@ func TestGatekeeperEnabled(t *testing.T) {
 	}{{true, true}, {false, false}}
 
 	for _, test := range tests {
-		policyConf := types.PolicyConfig{InformGatekeeperPolicies: test.Enabled}
+		var policyConf types.PolicyConfig
+		policyConf.InformGatekeeperPolicies = test.Enabled
 		assertEqual(t, g.Enabled(&policyConf), test.Expected)
 	}
 }

--- a/internal/expanders/kyverno_test.go
+++ b/internal/expanders/kyverno_test.go
@@ -77,7 +77,8 @@ func TestKyvernoEnabled(t *testing.T) {
 	}{{true, true}, {false, false}}
 
 	for _, test := range tests {
-		policyConf := types.PolicyConfig{InformKyvernoPolicies: test.Enabled}
+		var policyConf types.PolicyConfig
+		policyConf.InformKyvernoPolicies = test.Enabled
 		assertEqual(t, k.Enabled(&policyConf), test.Expected)
 	}
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -599,8 +599,8 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			}
 
 			selector := manifest.NamespaceSelector
-			if selector.Exclude != nil || selector.Include != nil ||
-				selector.MatchLabels != nil || selector.MatchExpressions != nil {
+			if selector.Exclude == nil && selector.Include == nil &&
+				selector.MatchLabels == nil && selector.MatchExpressions == nil {
 				manifest.NamespaceSelector = policy.NamespaceSelector
 			}
 

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -578,12 +578,12 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			}
 
 			// If the manifests are consolidated to a single ConfigurationPolicy object, don't set
-			// the evaluation interval per manifest.
+			// ConfigurationPolicy options per manifest.
 			if policy.ConsolidateManifests {
 				continue
 			}
 
-			// Only use the policy's evaluationInterval value when it's not explicitly set in the manifest.
+			// Only use the policy's ConfigurationPolicyOptions values when they're not explicitly set in the manifest.
 			if manifest.EvaluationInterval.Compliant == "" {
 				set := isEvaluationIntervalSetManifest(unmarshaledConfig, i, j, "compliant")
 				if !set {
@@ -598,8 +598,22 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 				}
 			}
 
+			selector := manifest.NamespaceSelector
+			if selector.Exclude != nil || selector.Include != nil ||
+				selector.MatchLabels != nil || selector.MatchExpressions != nil {
+				manifest.NamespaceSelector = policy.NamespaceSelector
+			}
+
+			if manifest.RemediationAction == "" && policy.RemediationAction != "" {
+				manifest.RemediationAction = policy.RemediationAction
+			}
+
 			if manifest.PruneObjectBehavior == "" && policy.PruneObjectBehavior != "" {
 				manifest.PruneObjectBehavior = policy.PruneObjectBehavior
+			}
+
+			if manifest.Severity == "" && manifest.Severity != "" {
+				manifest.Severity = policy.Severity
 			}
 		}
 
@@ -805,25 +819,37 @@ func (p *Plugin) assertValidConfig() error {
 				return err
 			}
 
+			evalInterval := manifest.EvaluationInterval
+
 			// Verify that consolidated manifests don't specify fields
 			// that can't be overridden at the objectTemplate level
-			if policy.ConsolidateManifests && manifest.PruneObjectBehavior != "" {
-				return fmt.Errorf(
-					"the policy %s has the pruneObjectBehavior value set on manifest[%d] but "+
-						"consolidateManifests is true",
-					policy.Name,
-					j,
+			if policy.ConsolidateManifests {
+				errorMsgFmt := fmt.Sprintf(
+					"the policy %s has the %%s value set on manifest[%d] but consolidateManifests is true",
+					policy.Name, j,
 				)
-			}
 
-			evalInterval := &manifest.EvaluationInterval
-			if policy.ConsolidateManifests && (evalInterval.Compliant != "" || evalInterval.NonCompliant != "") {
-				return fmt.Errorf(
-					"the policy %s has the evaluationInterval value set on manifest[%d] but "+
-						"consolidateManifests is true",
-					policy.Name,
-					j,
-				)
+				if evalInterval.Compliant != "" || evalInterval.NonCompliant != "" {
+					return fmt.Errorf(errorMsgFmt, "evaluationInterval")
+				}
+
+				selector := manifest.NamespaceSelector
+				if selector.Exclude != nil || selector.Include != nil ||
+					selector.MatchLabels != nil || selector.MatchExpressions != nil {
+					return fmt.Errorf(errorMsgFmt, "namespaceSelector")
+				}
+
+				if manifest.PruneObjectBehavior != "" {
+					return fmt.Errorf(errorMsgFmt, "pruneObjectBehavior")
+				}
+
+				if manifest.RemediationAction != "" {
+					return fmt.Errorf(errorMsgFmt, "remediationAction")
+				}
+
+				if manifest.Severity != "" {
+					return fmt.Errorf(errorMsgFmt, "severity")
+				}
 			}
 
 			if evalInterval.Compliant != "" && evalInterval.Compliant != "never" {

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -22,7 +22,7 @@ const (
 	policyAPIGroup             = "policy.open-cluster-management.io"
 	policyAPIVersion           = policyAPIGroup + "/v1"
 	policyKind                 = "Policy"
-	poilcySetAPIVersion        = policyAPIGroup + "/v1beta1"
+	policySetAPIVersion        = policyAPIGroup + "/v1beta1"
 	policySetKind              = "PolicySet"
 	placementBindingAPIVersion = policyAPIGroup + "/v1"
 	placementBindingKind       = "PlacementBinding"
@@ -1185,7 +1185,7 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 // manifests specified in the configuration are invalid or can't be read.
 func (p *Plugin) createPolicySet(policySetConf *types.PolicySetConfig) error {
 	policyset := map[string]interface{}{
-		"apiVersion": poilcySetAPIVersion,
+		"apiVersion": policySetAPIVersion,
 		"kind":       policySetKind,
 		"metadata": map[string]interface{}{
 			"name":      policySetConf.Name,

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -66,12 +66,16 @@ type Plugin struct {
 }
 
 var defaults = types.PolicyDefaults{
-	Categories:        []string{"CM Configuration Management"},
-	ComplianceType:    "musthave",
-	Controls:          []string{"CM-2 Baseline Configuration"},
-	RemediationAction: "inform",
-	Severity:          "low",
-	Standards:         []string{"NIST SP 800-53"},
+	PolicyOptions: types.PolicyOptions{
+		Categories: []string{"CM Configuration Management"},
+		Controls:   []string{"CM-2 Baseline Configuration"},
+		Standards:  []string{"NIST SP 800-53"},
+	},
+	ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+		ComplianceType:    "musthave",
+		RemediationAction: "inform",
+		Severity:          "low",
+	},
 }
 
 // Config validates the input PolicyGenerator configuration, applies any missing defaults, and

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -1030,6 +1030,30 @@ func TestConfigInvalidManifestKey(t *testing.T) {
 			`the policy policy-app has the pruneObjectBehavior value set` +
 				` on manifest[0] but consolidateManifests is true`,
 		},
+		"namespaceSelector specified in manifest": {
+			"namespaceSelector",
+			"",
+			"",
+			`{"include": ["test"]}`,
+			`the policy policy-app has the namespaceSelector value set` +
+				` on manifest[0] but consolidateManifests is true`,
+		},
+		"remediationAction specified in manifest": {
+			"remediationAction",
+			"",
+			"",
+			"enforce",
+			`the policy policy-app has the remediationAction value set` +
+				` on manifest[0] but consolidateManifests is true`,
+		},
+		"severity specified in manifest": {
+			"severity",
+			"",
+			"",
+			"critical",
+			`the policy policy-app has the severity value set` +
+				` on manifest[0] but consolidateManifests is true`,
+		},
 	}
 
 	for testName, test := range tests {

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -1383,7 +1383,7 @@ func TestPolicySetConfig(t *testing.T) {
 					{
 						Name: "my-policyset",
 						Placement: types.PlacementConfig{
-							PlacementRuleName: "plrexisingname",
+							PlacementRuleName: "plrexistingname",
 							ClusterSelectors:  map[string]string{"cloud": "red hat"},
 						},
 					},
@@ -1415,7 +1415,7 @@ func TestPolicySetConfig(t *testing.T) {
 					{
 						Name: "my-policyset",
 						Placement: types.PlacementConfig{
-							PlacementRuleName: "plrexisingname",
+							PlacementRuleName: "plrexistingname",
 							LabelSelector:     map[string]string{"cloud": "red hat"},
 						},
 					},

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -289,7 +289,7 @@ policies:
 	}
 }
 
-func TestGeneratePolicyExisingPlacementRuleName(t *testing.T) {
+func TestGeneratePolicyExistingPlacementRuleName(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
@@ -380,7 +380,7 @@ subjects:
 	assertEqual(t, string(output), expected)
 }
 
-func TestGeneratePolicyExisingPlacementName(t *testing.T) {
+func TestGeneratePolicyExistingPlacementName(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -7,13 +7,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type PolicyOptions struct {
+	Categories                     []string          `json:"categories,omitempty" yaml:"categories,omitempty"`
+	Controls                       []string          `json:"controls,omitempty" yaml:"controls,omitempty"`
+	Placement                      PlacementConfig   `json:"placement,omitempty" yaml:"placement,omitempty"`
+	Standards                      []string          `json:"standards,omitempty" yaml:"standards,omitempty"`
+	ConsolidateManifests           bool              `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
+	Disabled                       bool              `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	InformGatekeeperPolicies       bool              `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
+	InformKyvernoPolicies          bool              `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	GeneratePlacementWhenInSet     bool              `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
+	PolicySets                     []string          `json:"policySets,omitempty" yaml:"policySets,omitempty"`
+	PolicyAnnotations              map[string]string `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
+	ConfigurationPolicyAnnotations map[string]string `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
+}
+
+type ConfigurationPolicyOptions struct {
+	RemediationAction      string             `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
+	Severity               string             `json:"severity,omitempty" yaml:"severity,omitempty"`
+	ComplianceType         string             `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
+	MetadataComplianceType string             `json:"metadataComplianceType,omitempty" yaml:"metadataComplianceType,omitempty"`
+	EvaluationInterval     EvaluationInterval `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
+	NamespaceSelector      NamespaceSelector  `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
+	PruneObjectBehavior    string             `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
+}
+
 type Manifest struct {
-	ComplianceType         string                   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
-	MetadataComplianceType string                   `json:"metadataComplianceType,omitempty" yaml:"metadataComplianceType,omitempty"`
-	EvaluationInterval     EvaluationInterval       `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
-	PruneObjectBehavior    string                   `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
-	Patches                []map[string]interface{} `json:"patches,omitempty" yaml:"patches,omitempty"`
-	Path                   string                   `json:"path,omitempty" yaml:"path,omitempty"`
+	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	Patches                    []map[string]interface{} `json:"patches,omitempty" yaml:"patches,omitempty"`
+	Path                       string                   `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 type NamespaceSelector struct {
@@ -58,60 +80,23 @@ type EvaluationInterval struct {
 
 // PolicyConfig represents a policy entry in the PolicyGenerator configuration.
 type PolicyConfig struct {
-	Categories             []string `json:"categories,omitempty" yaml:"categories,omitempty"`
-	ComplianceType         string   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
-	MetadataComplianceType string   `json:"metadataComplianceType,omitempty" yaml:"metadataComplianceType,omitempty"`
-	Controls               []string `json:"controls,omitempty" yaml:"controls,omitempty"`
+	PolicyOptions              `json:",inline" yaml:",inline"`
+	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	Name                       string `json:"name,omitempty" yaml:"name,omitempty"`
 	// This a slice of structs to allow additional configuration related to a manifest such as
 	// accepting patches.
-	Manifests         []Manifest        `json:"manifests,omitempty" yaml:"manifests,omitempty"`
-	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
-	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
-	// This is named Placement so that eventually PlacementRules and Placements will be supported
-	Placement                      PlacementConfig    `json:"placement,omitempty" yaml:"placement,omitempty"`
-	RemediationAction              string             `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
-	Severity                       string             `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Standards                      []string           `json:"standards,omitempty" yaml:"standards,omitempty"`
-	ConsolidateManifests           bool               `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
-	Disabled                       bool               `json:"disabled,omitempty" yaml:"disabled,omitempty"`
-	InformGatekeeperPolicies       bool               `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
-	InformKyvernoPolicies          bool               `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
-	GeneratePlacementWhenInSet     bool               `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
-	PolicySets                     []string           `json:"policySets,omitempty" yaml:"policySets,omitempty"`
-	EvaluationInterval             EvaluationInterval `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
-	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
-	ConfigurationPolicyAnnotations map[string]string  `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
-	PruneObjectBehavior            string             `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
+	Manifests []Manifest `json:"manifests,omitempty" yaml:"manifests,omitempty"`
 }
 
 type PolicyDefaults struct {
-	Categories             []string          `json:"categories,omitempty" yaml:"categories,omitempty"`
-	ComplianceType         string            `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
-	MetadataComplianceType string            `json:"metadataComplianceType,omitempty" yaml:"metadataComplianceType,omitempty"`
-	Controls               []string          `json:"controls,omitempty" yaml:"controls,omitempty"`
-	Namespace              string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	NamespaceSelector      NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
-	// This is named Placement so that eventually PlacementRules and Placements will be supported
-	Placement                      PlacementConfig    `json:"placement,omitempty" yaml:"placement,omitempty"`
-	RemediationAction              string             `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
-	Severity                       string             `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Standards                      []string           `json:"standards,omitempty" yaml:"standards,omitempty"`
-	ConsolidateManifests           bool               `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
-	Disabled                       bool               `json:"disabled,omitempty" yaml:"disabled,omitempty"`
-	InformGatekeeperPolicies       bool               `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
-	InformKyvernoPolicies          bool               `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
-	GeneratePlacementWhenInSet     bool               `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
-	PolicySets                     []string           `json:"policySets,omitempty" yaml:"policySets,omitempty"`
-	EvaluationInterval             EvaluationInterval `json:"evaluationInterval,omitempty" yaml:"evaluationInterval,omitempty"`
-	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
-	ConfigurationPolicyAnnotations map[string]string  `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
-	PruneObjectBehavior            string             `json:"pruneObjectBehavior,omitempty" yaml:"pruneObjectBehavior,omitempty"`
+	PolicyOptions              `json:",inline" yaml:",inline"`
+	ConfigurationPolicyOptions `json:",inline" yaml:",inline"`
+	Namespace                  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
 type PolicySetConfig struct {
-	Name        string   `json:"name,omitempty" yaml:"name,omitempty"`
-	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
-	Policies    []string `json:"policies,omitempty" yaml:"policies,omitempty"`
-	// This is named Placement so that eventually PlacementRules and Placements will be supported
-	Placement PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+	Name        string          `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
+	Policies    []string        `json:"policies,omitempty" yaml:"policies,omitempty"`
+	Placement   PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -135,18 +135,22 @@ data:
 		// The applyDefaults method would normally fill in ComplianceType on each manifest entry.
 		manifestFiles = append(
 			manifestFiles, types.Manifest{
-				ComplianceType:         "musthave",
-				MetadataComplianceType: "mustonlyhave",
-				Path:                   manifestPath,
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+					ComplianceType:         "musthave",
+					MetadataComplianceType: "mustonlyhave",
+				},
+				Path: manifestPath,
 			},
 		)
 
 		manifestFilesMustNotHave = append(
 			manifestFilesMustNotHave,
 			types.Manifest{
-				ComplianceType:         "mustnothave",
-				MetadataComplianceType: "musthave",
-				Path:                   manifestPath,
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+					ComplianceType:         "mustnothave",
+					MetadataComplianceType: "musthave",
+				},
+				Path: manifestPath,
 			},
 		)
 	}
@@ -180,7 +184,10 @@ data:
 		{
 			ExpectedComplianceType:         "musthave",
 			ExpectedMetadataComplianceType: "",
-			Manifests:                      []types.Manifest{{ComplianceType: "musthave", Path: tmpDir}},
+			Manifests: []types.Manifest{{
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{ComplianceType: "musthave"},
+				Path:                       tmpDir,
+			}},
 		},
 	}
 	// test ConsolidateManifests = true (default case)
@@ -188,12 +195,16 @@ data:
 	// and two objTemplate under this policyTemplate
 	for _, test := range tests {
 		policyConf := types.PolicyConfig{
-			ComplianceType:       "musthave",
-			ConsolidateManifests: true,
-			Manifests:            test.Manifests,
-			Name:                 "policy-app-config",
-			RemediationAction:    "inform",
-			Severity:             "low",
+			PolicyOptions: types.PolicyOptions{
+				ConsolidateManifests: true,
+			},
+			ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+				ComplianceType:    "musthave",
+				RemediationAction: "inform",
+				Severity:          "low",
+			},
+			Manifests: test.Manifests,
+			Name:      "policy-app-config",
 		}
 
 		policyTemplates, err := getPolicyTemplates(&policyConf)
@@ -341,15 +352,21 @@ resources:
 	}
 	for _, test := range tests {
 		policyConf := types.PolicyConfig{
-			ComplianceType:       "musthave",
-			ConsolidateManifests: true,
+			ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+				ComplianceType:    "musthave",
+				RemediationAction: "inform",
+				Severity:          "low",
+			},
 			Manifests: []types.Manifest{{
-				ComplianceType: "musthave",
-				Path:           test.ManifestPath,
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+					ComplianceType: "musthave",
+				},
+				Path: test.ManifestPath,
 			}},
-			Name:              "policy-kustomize",
-			RemediationAction: "inform",
-			Severity:          "low",
+			PolicyOptions: types.PolicyOptions{
+				ConsolidateManifests: true,
+			},
+			Name: "policy-kustomize",
 		}
 
 		policyTemplates, err := getPolicyTemplates(&policyConf)
@@ -438,9 +455,11 @@ data:
 		// The applyDefaults method would normally fill in ComplianceType on each manifest entry.
 		manifestFiles = append(
 			manifestFiles, types.Manifest{
-				ComplianceType:         "musthave",
-				MetadataComplianceType: "mustonlyhave",
-				Path:                   manifestPath,
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+					ComplianceType:         "musthave",
+					MetadataComplianceType: "mustonlyhave",
+				},
+				Path: manifestPath,
 			},
 		)
 	}
@@ -462,9 +481,11 @@ data:
 		// The applyDefaults method would normally fill in ComplianceType on each manifest entry.
 		{
 			Manifests: []types.Manifest{{
-				ComplianceType:         "musthave",
-				MetadataComplianceType: "mustonlyhave",
-				Path:                   tmpDir,
+				ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+					ComplianceType:         "musthave",
+					MetadataComplianceType: "mustonlyhave",
+				},
+				Path: tmpDir,
 			}},
 		},
 	}
@@ -474,13 +495,17 @@ data:
 	// and each policyTemplate has only one objTemplate
 	for _, test := range tests {
 		policyConf := types.PolicyConfig{
-			ComplianceType:         "musthave",
-			MetadataComplianceType: "musthave",
-			ConsolidateManifests:   false,
-			Manifests:              test.Manifests,
-			Name:                   "policy-app-config",
-			RemediationAction:      "inform",
-			Severity:               "low",
+			PolicyOptions: types.PolicyOptions{
+				ConsolidateManifests: false,
+			},
+			ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+				ComplianceType:         "musthave",
+				MetadataComplianceType: "musthave",
+				RemediationAction:      "inform",
+				Severity:               "low",
+			},
+			Manifests: test.Manifests,
+			Name:      "policy-app-config",
 		}
 
 		policyTemplates, err := getPolicyTemplates(&policyConf)
@@ -617,10 +642,12 @@ func TestGetPolicyTemplateFromPolicyTypeManifest(t *testing.T) {
 
 	for _, test := range tests {
 		policyConf := types.PolicyConfig{
-			Manifests:         test.Manifests,
-			Name:              "policy-limitclusteradmin",
-			RemediationAction: "inform",
-			Severity:          "low",
+			Manifests: test.Manifests,
+			Name:      "policy-limitclusteradmin",
+			ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+				RemediationAction: "inform",
+				Severity:          "low",
+			},
 		}
 
 		policyTemplates, err := getPolicyTemplates(&policyConf)
@@ -913,12 +940,16 @@ metadata:
 	}
 
 	policyConf := types.PolicyConfig{
-		ComplianceType:        "musthave",
-		InformKyvernoPolicies: true,
-		Manifests:             []types.Manifest{{Path: manifestPath}},
-		Name:                  "policy-kyverno-config",
-		RemediationAction:     "enforce",
-		Severity:              "low",
+		PolicyOptions: types.PolicyOptions{
+			InformKyvernoPolicies: true,
+		},
+		ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+			ComplianceType:    "musthave",
+			RemediationAction: "enforce",
+			Severity:          "low",
+		},
+		Manifests: []types.Manifest{{Path: manifestPath}},
+		Name:      "policy-kyverno-config",
 	}
 
 	policyTemplates, err := getPolicyTemplates(&policyConf)
@@ -969,11 +1000,13 @@ func TestGetPolicyTemplateNoManifests(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	policyConf := types.PolicyConfig{
-		ComplianceType:    "musthave",
-		Manifests:         []types.Manifest{{Path: tmpDir}},
-		Name:              "policy-app-config",
-		RemediationAction: "inform",
-		Severity:          "low",
+		ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+			ComplianceType:    "musthave",
+			RemediationAction: "inform",
+			Severity:          "low",
+		},
+		Manifests: []types.Manifest{{Path: tmpDir}},
+		Name:      "policy-app-config",
 	}
 
 	_, err := getPolicyTemplates(&policyConf)
@@ -990,11 +1023,18 @@ func TestGetPolicyTemplateInvalidPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	manifestPath := path.Join(tmpDir, "does-not-exist.yaml")
 	policyConf := types.PolicyConfig{
-		ComplianceType:    "musthave",
-		Manifests:         []types.Manifest{{ComplianceType: "musthave", Path: manifestPath}},
-		Name:              "policy-app-config",
-		RemediationAction: "inform",
-		Severity:          "low",
+		ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+			ComplianceType:    "musthave",
+			RemediationAction: "inform",
+			Severity:          "low",
+		},
+		Manifests: []types.Manifest{{
+			ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+				ComplianceType: "musthave",
+			},
+			Path: manifestPath,
+		}},
+		Name: "policy-app-config",
 	}
 
 	_, err := getPolicyTemplates(&policyConf)
@@ -1017,11 +1057,13 @@ func TestGetPolicyTemplateInvalidManifest(t *testing.T) {
 	}
 
 	policyConf := types.PolicyConfig{
-		ComplianceType:    "musthave",
-		Manifests:         []types.Manifest{{Path: manifestPath}},
-		Name:              "policy-app-config",
-		RemediationAction: "inform",
-		Severity:          "low",
+		ConfigurationPolicyOptions: types.ConfigurationPolicyOptions{
+			ComplianceType:    "musthave",
+			RemediationAction: "inform",
+			Severity:          "low",
+		},
+		Manifests: []types.Manifest{{Path: manifestPath}},
+		Name:      "policy-app-config",
 	}
 
 	_, err = getPolicyTemplates(&policyConf)


### PR DESCRIPTION
This PR is twofold:
- Implement `PolicyOptions` and `ConfigurationPolicyOptions`, which folds keys into a single struct that can be used in the `PolicyDefaults`, `Policy`, and `Manifests` structs.
- The consolidation brings consistency to overrides in `Manifests` that was missing previously, so this also adds the required validation and overrides there