### PR TITLE
Fix the Gatekeeper expander event inform policy

### DIFF
--- a/internal/expanders/gatekeeper.go
+++ b/internal/expanders/gatekeeper.go
@@ -105,13 +105,11 @@ func (g GatekeeperPolicyExpander) Expand(
 						"objectDefinition": map[string]interface{}{
 							"apiVersion": "v1",
 							"kind":       "Event",
-							"annotations": []map[string]interface{}{
-								{
-									"constraint_action": "deny",
-									"constraint_kind":   constraintKind,
-									"constraint_name":   constraintName,
-									"event_type":        "violation",
-								},
+							"annotations": map[string]interface{}{
+								"constraint_action": "deny",
+								"constraint_kind":   constraintKind,
+								"constraint_name":   constraintName,
+								"event_type":        "violation",
 							},
 						},
 					},

--- a/internal/expanders/gatekeeper_test.go
+++ b/internal/expanders/gatekeeper_test.go
@@ -141,13 +141,11 @@ func TestGatekeeperExpand(t *testing.T) {
 							"objectDefinition": map[string]interface{}{
 								"apiVersion": "v1",
 								"kind":       "Event",
-								"annotations": []map[string]interface{}{
-									{
-										"constraint_action": "deny",
-										"constraint_kind":   "MyConstraint",
-										"constraint_name":   "my-awesome-constraint",
-										"event_type":        "violation",
-									},
+								"annotations": map[string]interface{}{
+									"constraint_action": "deny",
+									"constraint_kind":   "MyConstraint",
+									"constraint_name":   "my-awesome-constraint",
+									"event_type":        "violation",
 								},
 							},
 						},


### PR DESCRIPTION
This was accidentally checking for annotations in the format of an array of maps but it should just be a map.

Signed-off-by: mprahl <mprahl@users.noreply.github.com>