### PR TITLE
Add options for policy ordering

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/pflag"
@@ -61,7 +60,7 @@ func processGeneratorConfig(filePath string) []byte {
 	p := internal.Plugin{}
 
 	// #nosec G304
-	fileData, err := ioutil.ReadFile(filePath)
+	fileData, err := os.ReadFile(filePath)
 	if err != nil {
 		errorAndExit("failed to read file '%s': %s", filePath, err)
 	}

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -10,6 +10,11 @@ placementBindingDefaults:
   # Set an explicit placement binding name to use rather than rely on the default.
   name: ""
 
+# Optional. Determines whether to define dependencies on the policies so they are applied in the
+# order they are defined in the manifests list. This defaults to false, and all the policies
+# can be applied at the same time.
+orderViaDependencies: false
+
 # Required. Any default value listed here can be overridden under an entry in the policies array
 # except for "namespace".
 policyDefaults:
@@ -32,6 +37,21 @@ policyDefaults:
   # manifests being wrapped in the policy. If set to false, a configuration policy per manifest will
   # be generated. This defaults to true.
   consolidateManifests: true
+  # Optional. A list of objects that should be in specific compliance states before this policy is
+  # applied.
+  dependencies:
+      # Required. The name of the object being depended on.
+    - name: ""
+      # Optional. The namespace of the object being depended on. Will default to the namespace of
+      # policies from this generator.
+      namespace: ""
+      # Optional. The compliance state the object should be in. Defaults to "Compliant"
+      compliance: "Compliant"
+      # Optional. The kind of the object. Defaults to "Policy", but can also be things like
+      # ConfigurationPolicy.
+      kind: "Policy"
+      # Optional. The APIVersion of the object. Defaults to "policy.open-cluster-management.io/v1"
+      apiVersion: "policy.open-cluster-management.io/v1"
   # Optional. Determines whether the policy is enabled or disabled. A disabled policy will not be
   # propagated to any managed clusters and will show no status as a result.
   disabled: false
@@ -47,6 +67,9 @@ policyDefaults:
   # deleted. Pruning only takes place if the remediation action of the policy has been set to "enforce". Example values
   # are "DeleteIfCreated", "DeleteAll", or "None". This defaults to unset, which is equivalent to "None".
   pruneObjectBehavior: "None"
+  # Optional. Determines whether to treat the policy as compliant when it is waiting for its
+  # dependencies to reach their desired states. Defaults to false.
+  ignorePending: false
   # Optional. When the policy references a Gatekeeper policy manifest, this determines if an additional
   # configuration policy should be generated in order to receive policy violations in Open Cluster
   # Management when the Gatekeeper policy has been violated. This defaults to true.
@@ -191,12 +214,27 @@ policies:
     # Optional. (See policyDefaults.controls for description.)
     controls:
       - "CM-2 Baseline Configuration"
+    # Optional. (See policyDefaults.dependencies for description.) Note: the list defined here will
+    # be merged with the default list.
+    dependencies:
+        # Required. (See policyDefaults.dependencies.name for description.)
+      - name: ""
+        # Optional. (See policyDefaults.dependencies.namespace for description.)
+        namespace: ""
+        # Optional. (See policyDefaults.dependencies.compliance for description.)
+        compliance: "Compliant"
+        # Optional. (See policyDefaults.dependencies.kind for description.)
+        kind: "Policy"
+        # Optional. (See policyDefaults.dependencies.apiVersion for description.)
+        apiVersion: "policy.open-cluster-management.io/v1"
     # Optional. (See policyDefaults.disabled for description.)
     disabled: false
     # Optional. (See policyDefaults.evaluationInterval for description.)
     evaluationInterval: {}
     # Optional. (See policyDefaults.pruneObjectBehavior for description.)
     pruneObjectBehavior: ""
+    # Optional. (See policyDefaults.ignorePending for description.)
+    ignorePending: false
     # Optional. (See policyDefaults.informGatekeeperPolicies for description.)
     informGatekeeperPolicies: true
     # Optional. (See policyDefaults.informKyvernoPolicies for description.)

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -46,6 +46,8 @@ type Plugin struct {
 	PlacementBindingDefaults struct {
 		Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	} `json:"placementBindingDefaults,omitempty" yaml:"placementBindingDefaults,omitempty"`
+	OrderViaDependencies bool `json:"orderViaDependencies,omitempty" yaml:"orderViaDependencies,omitempty"`
+
 	PolicyDefaults types.PolicyDefaults    `json:"policyDefaults,omitempty" yaml:"policyDefaults,omitempty"`
 	Policies       []types.PolicyConfig    `json:"policies" yaml:"policies"`
 	PolicySets     []types.PolicySetConfig `json:"policySets" yaml:"policySets"`
@@ -411,6 +413,27 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 		}
 	}
 
+	for i, dep := range p.PolicyDefaults.Dependencies {
+		if dep.Namespace == "" {
+			p.PolicyDefaults.Dependencies[i].Namespace = p.PolicyDefaults.Namespace
+		}
+
+		if dep.Compliance == "" {
+			p.PolicyDefaults.Dependencies[i].Compliance = "Compliant"
+		}
+
+		if dep.Kind == "" {
+			p.PolicyDefaults.Dependencies[i].Kind = policyKind
+		}
+
+		if dep.APIVersion == "" {
+			p.PolicyDefaults.Dependencies[i].APIVersion = policyAPIVersion
+		}
+	}
+
+	// Used when p.OrderViaDependencies is set
+	prevPolicyName := ""
+
 	for i := range p.Policies {
 		policy := &p.Policies[i]
 
@@ -511,6 +534,43 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			policy.Disabled = disabledValue
 		} else {
 			policy.Disabled = p.PolicyDefaults.Disabled
+		}
+
+		ignorePending, ignorePendingIsSet := getPolicyBool(unmarshaledConfig, i, "ignorePending")
+		if ignorePendingIsSet {
+			policy.IgnorePending = ignorePending
+		} else {
+			policy.IgnorePending = p.PolicyDefaults.IgnorePending
+		}
+
+		for i, dep := range policy.Dependencies {
+			if dep.Namespace == "" {
+				policy.Dependencies[i].Namespace = p.PolicyDefaults.Namespace
+			}
+
+			if dep.Compliance == "" {
+				policy.Dependencies[i].Compliance = "Compliant"
+			}
+
+			if dep.Kind == "" {
+				policy.Dependencies[i].Kind = policyKind
+			}
+
+			if dep.APIVersion == "" {
+				policy.Dependencies[i].APIVersion = policyAPIVersion
+			}
+		}
+
+		policy.Dependencies = append(policy.Dependencies, p.PolicyDefaults.Dependencies...)
+
+		if p.OrderViaDependencies && prevPolicyName != "" {
+			policy.Dependencies = append(policy.Dependencies, types.PolicyDependency{
+				Name:       prevPolicyName,
+				Namespace:  p.PolicyDefaults.Namespace,
+				Compliance: "Compliant",
+				Kind:       policyKind,
+				APIVersion: policyAPIVersion,
+			})
 		}
 
 		// Determine whether defaults are set for placement
@@ -640,6 +700,8 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 		for plcset := range plcToPlcset[policy.Name] {
 			policy.PolicySets = append(policy.PolicySets, plcset)
 		}
+
+		prevPolicyName = policy.Name
 	}
 
 	// Sync up the declared policy sets in p.Policies[*]
@@ -738,6 +800,12 @@ func (p *Plugin) assertValidConfig() error {
 
 	if len(p.Policies) == 0 {
 		return errors.New("policies is empty but it must be set")
+	}
+
+	for i, dep := range p.PolicyDefaults.Dependencies {
+		if dep.Name == "" {
+			return fmt.Errorf("dependency name must be set in policyDefaults dependency %v", i)
+		}
 	}
 
 	seenPlc := map[string]bool{}
@@ -985,6 +1053,12 @@ func (p *Plugin) assertValidConfig() error {
 				)
 			}
 		}
+
+		for i, dep := range policy.Dependencies {
+			if dep.Name == "" {
+				return fmt.Errorf("dependency name must be set in policy %v dependency %v", policy.Name, i)
+			}
+		}
 	}
 
 	seenPlcset := map[string]bool{}
@@ -1153,6 +1227,15 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 		policyConf.Standards, ",",
 	)
 
+	spec := map[string]interface{}{
+		"disabled":         policyConf.Disabled,
+		"policy-templates": policyTemplates,
+	}
+
+	if len(policyConf.Dependencies) != 0 {
+		spec["dependencies"] = policyConf.Dependencies
+	}
+
 	policy := map[string]interface{}{
 		"apiVersion": policyAPIVersion,
 		"kind":       policyKind,
@@ -1161,10 +1244,7 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 			"name":        policyConf.Name,
 			"namespace":   p.PolicyDefaults.Namespace,
 		},
-		"spec": map[string]interface{}{
-			"disabled":         policyConf.Disabled,
-			"policy-templates": policyTemplates,
-		},
+		"spec": spec,
 	}
 
 	policyYAML, err := yaml.Marshal(policy)

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -3,7 +3,7 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -24,7 +24,7 @@ data:
   game.properties: enemies=potato
 `
 
-	err := ioutil.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestsPath)
 	}
@@ -48,7 +48,7 @@ spec:
   maxClusterRoleBindingUsers: 5
 `
 
-	err := ioutil.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestsPath)
 	}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -4,7 +4,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -1022,7 +1022,7 @@ func TestCreatePolicyInvalidYAML(t *testing.T) {
 	tmpDir := t.TempDir()
 	manifestPath := path.Join(tmpDir, "configmap.yaml")
 
-	err := ioutil.WriteFile(manifestPath, []byte("$ not Yaml!"), 0o666)
+	err := os.WriteFile(manifestPath, []byte("$ not Yaml!"), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to create %s: %v", manifestPath, err)
 	}
@@ -1061,7 +1061,7 @@ metadata:
   name: policy-limitclusteradmin-example
 `
 
-	err := ioutil.WriteFile(manifestPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to create %s: %v", manifestPath, err)
 	}
@@ -1303,7 +1303,7 @@ func plPathHelper(t *testing.T, plrYAML string, usingPlR bool) (*Plugin, string)
 	plrPath := path.Join(tmpDir, "pl.yaml")
 	plrYAML = strings.TrimPrefix(plrYAML, "\n")
 
-	err := ioutil.WriteFile(plrPath, []byte(plrYAML), 0o666)
+	err := os.WriteFile(plrPath, []byte(plrYAML), 0o666)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -8,18 +8,20 @@ import (
 )
 
 type PolicyOptions struct {
-	Categories                     []string          `json:"categories,omitempty" yaml:"categories,omitempty"`
-	Controls                       []string          `json:"controls,omitempty" yaml:"controls,omitempty"`
-	Placement                      PlacementConfig   `json:"placement,omitempty" yaml:"placement,omitempty"`
-	Standards                      []string          `json:"standards,omitempty" yaml:"standards,omitempty"`
-	ConsolidateManifests           bool              `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
-	Disabled                       bool              `json:"disabled,omitempty" yaml:"disabled,omitempty"`
-	InformGatekeeperPolicies       bool              `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
-	InformKyvernoPolicies          bool              `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
-	GeneratePlacementWhenInSet     bool              `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
-	PolicySets                     []string          `json:"policySets,omitempty" yaml:"policySets,omitempty"`
-	PolicyAnnotations              map[string]string `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
-	ConfigurationPolicyAnnotations map[string]string `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
+	Categories                     []string           `json:"categories,omitempty" yaml:"categories,omitempty"`
+	Controls                       []string           `json:"controls,omitempty" yaml:"controls,omitempty"`
+	Dependencies                   []PolicyDependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Placement                      PlacementConfig    `json:"placement,omitempty" yaml:"placement,omitempty"`
+	Standards                      []string           `json:"standards,omitempty" yaml:"standards,omitempty"`
+	ConsolidateManifests           bool               `json:"consolidateManifests,omitempty" yaml:"consolidateManifests,omitempty"`
+	Disabled                       bool               `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	IgnorePending                  bool               `json:"ignorePending,omitempty" yaml:"ignorePending,omitempty"`
+	InformGatekeeperPolicies       bool               `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
+	InformKyvernoPolicies          bool               `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	GeneratePlacementWhenInSet     bool               `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
+	PolicySets                     []string           `json:"policySets,omitempty" yaml:"policySets,omitempty"`
+	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`
+	ConfigurationPolicyAnnotations map[string]string  `json:"configurationPolicyAnnotations,omitempty" yaml:"configurationPolicyAnnotations,omitempty"`
 }
 
 type ConfigurationPolicyOptions struct {
@@ -99,4 +101,12 @@ type PolicySetConfig struct {
 	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
 	Policies    []string        `json:"policies,omitempty" yaml:"policies,omitempty"`
 	Placement   PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+}
+
+type PolicyDependency struct {
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Compliance string `json:"compliance,omitempty" yaml:"compliance,omitempty"`
+	Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Name       string `json:"name" yaml:"name"`
+	Namespace  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -40,7 +39,7 @@ func getManifests(policyConf *types.PolicyConfig) ([][]map[string]interface{}, e
 		resolvedFiles := []string{}
 
 		if manifestPathInfo.IsDir() {
-			files, err := ioutil.ReadDir(manifest.Path)
+			files, err := os.ReadDir(manifest.Path)
 			if err != nil {
 				return nil, readErr
 			}
@@ -405,7 +404,7 @@ func handleExpanders(
 // be returned.
 func unmarshalManifestFile(manifestPath string) ([]map[string]interface{}, error) {
 	// #nosec G304
-	manifestBytes, err := ioutil.ReadFile(manifestPath)
+	manifestBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the manifest file %s", manifestPath)
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -194,6 +194,10 @@ func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]map[string
 				"objectDefinition": manifest,
 			}
 
+			if policyConf.IgnorePending {
+				objTemplate["ignorePending"] = policyConf.IgnorePending
+			}
+
 			if metadataComplianceType != "" {
 				objTemplate["metadataComplianceType"] = metadataComplianceType
 			}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"open-cluster-management.io/ocm-kustomize-generator-plugins/internal/types"
 )
@@ -18,7 +19,7 @@ func assertEqual(t *testing.T, a interface{}, b interface{}) {
 	t.Helper()
 
 	if a != b {
-		t.Fatalf("%s != %s", a, b)
+		t.Fatalf(cmp.Diff(a, b))
 	}
 }
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -3,7 +3,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -128,7 +127,7 @@ data:
 			enemy,
 		)
 
-		err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+		err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 		if err != nil {
 			t.Fatalf("Failed to write %s", manifestPath)
 		}
@@ -160,7 +159,7 @@ data:
 	// template
 	bogusFilePath := path.Join(tmpDir, "README.md")
 
-	err := ioutil.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
+	err := os.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", bogusFilePath)
 	}
@@ -291,7 +290,7 @@ data:
 			i, enemy,
 		)
 
-		err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+		err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 		if err != nil {
 			t.Fatalf("Failed to write %s", manifestPath)
 		}
@@ -314,7 +313,7 @@ resources:
 	}
 
 	for kustomizePath, kustomizeYAML := range kustomizeManifests {
-		err := ioutil.WriteFile(kustomizePath, []byte(kustomizeYAML), 0o666)
+		err := os.WriteFile(kustomizePath, []byte(kustomizeYAML), 0o666)
 		if err != nil {
 			t.Fatalf("Failed to write %s", kustomizePath)
 		}
@@ -331,7 +330,7 @@ resources:
 	// Write a bogus file to verify it is not picked up when creating the policy template
 	bogusFilePath := path.Join(kustomizeDir, "this-other-file.yaml")
 
-	err = ioutil.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
+	err = os.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", bogusFilePath)
 	}
@@ -448,7 +447,7 @@ data:
 			enemy,
 		)
 
-		err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+		err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 		if err != nil {
 			t.Fatalf("Failed to write %s", manifestPath)
 		}
@@ -469,7 +468,7 @@ data:
 	// template
 	bogusFilePath := path.Join(tmpDir, "README.md")
 
-	err := ioutil.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
+	err := os.WriteFile(bogusFilePath, []byte("# My Manifests"), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", bogusFilePath)
 	}
@@ -699,7 +698,7 @@ data:
   game.properties: enemies=potato
 `
 
-	err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+	err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -787,7 +786,7 @@ data:
   image: "quay.io/potatos1"
 `
 
-	err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+	err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -896,7 +895,7 @@ data:
   image: "quay.io/potatos1"
 `
 
-	err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+	err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -935,7 +934,7 @@ kind: ClusterPolicy
 metadata:
   name: my-awesome-policy`
 
-	err := ioutil.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
+	err := os.WriteFile(manifestPath, []byte(manifestYAML), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -1052,7 +1051,7 @@ func TestGetPolicyTemplateInvalidManifest(t *testing.T) {
 	tmpDir := t.TempDir()
 	manifestPath := path.Join(tmpDir, "configmap.yaml")
 	// Ensure an error is returned when there is an invalid manifest file
-	err := ioutil.WriteFile(manifestPath, []byte("$i am not YAML!"), 0o666)
+	err := os.WriteFile(manifestPath, []byte("$i am not YAML!"), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -1101,7 +1100,7 @@ data:
     enemies=potato
 `
 
-	err := ioutil.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestsPath)
 	}
@@ -1146,7 +1145,7 @@ data:
 ---
 `
 
-	err := ioutil.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestsPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestsPath)
 	}
@@ -1185,7 +1184,7 @@ func TestUnmarshalManifestFileInvalidYAML(t *testing.T) {
 	manifestPath := path.Join(tmpDir, "configmaps.yaml")
 	yamlContent := `$I am not YAML`
 
-	err := ioutil.WriteFile(manifestPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -1202,7 +1201,7 @@ func TestUnmarshalManifestFileNotObject(t *testing.T) {
 	manifestPath := path.Join(tmpDir, "configmaps.yaml")
 	yamlContent := `- i am an array`
 
-	err := ioutil.WriteFile(manifestPath, []byte(yamlContent), 0o666)
+	err := os.WriteFile(manifestPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
@@ -1262,14 +1261,14 @@ func TestVerifyManifestPath(t *testing.T) {
 	manifestPath := path.Join(workingDir, "configmap.yaml")
 	yamlContent := "---\nkind: ConfigMap"
 
-	err = ioutil.WriteFile(manifestPath, []byte(yamlContent), 0o666)
+	err = os.WriteFile(manifestPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
 
 	otherManifestPath := path.Join(otherDir, "configmap.yaml")
 
-	err = ioutil.WriteFile(otherManifestPath, []byte(yamlContent), 0o666)
+	err = os.WriteFile(otherManifestPath, []byte(yamlContent), 0o666)
 	if err != nil {
 		t.Fatalf("Failed to write %s", otherManifestPath)
 	}
@@ -1399,7 +1398,7 @@ data:
 	for filename, content := range manifestPaths {
 		manifestPath := path.Join(kustomizeDir, filename)
 
-		err = ioutil.WriteFile(manifestPath, []byte(content), 0o666)
+		err = os.WriteFile(manifestPath, []byte(content), 0o666)
 		if err != nil {
 			t.Fatalf("Failed to write %s", manifestPath)
 		}


### PR DESCRIPTION
The new `dependencies` field in the generator is the same as the new `dependencies` field in the Policy type, however, more fields are optional and will be filled in by the generator with useful defaults.

The new `ignorePending` field is also the same, but since that would be set on templates, and the generator does not expose much at the template level, here the field is set on the policy, and the generator sets the correct field in all the templates of that policy. For a similar reason, the `extraDependencies` field is not exposed in the generator at all.

The new `orderViaDependencies` field will set up a chain of dependencies on the created policies. So if 3 policies are created by the generator, policy 2 will depend on policy 1, and policy 3 will depend on policy 2.

In all cases, dependency lists are merged - setting it on a specific policy will *not* override the defaults, or a dependency added by the `orderViaDependencies` flag.

Refs:
 - https://github.com/stolostron/backlog/issues/26183

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>