### PR TITLE
Fix order manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module open-cluster-management.io/ocm-kustomize-generator-plugins
 go 1.18
 
 require (
+	github.com/google/go-cmp v0.5.7
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
@@ -22,7 +23,6 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -39,6 +39,7 @@ require (
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -1302,7 +1302,7 @@ func (p *Plugin) assertValidConfig() error {
 // The generated policy is written to the plugin's output buffer. An error is returned if the
 // manifests specified in the configuration are invalid or can't be read.
 func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
-	policyTemplates, err := getPolicyTemplates(policyConf, p.PolicyDefaults.Namespace)
+	policyTemplates, err := getPolicyTemplates(policyConf)
 	if err != nil {
 		return err
 	}

--- a/internal/testdata/ordering/three-ordered-manifests.yaml
+++ b/internal/testdata/ordering/three-ordered-manifests.yaml
@@ -33,7 +33,6 @@ spec:
         compliance: Compliant
         kind: ConfigurationPolicy
         name: one
-        namespace: my-policies
       objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -56,7 +55,6 @@ spec:
         compliance: Compliant
         kind: ConfigurationPolicy
         name: one2
-        namespace: my-policies
       objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -150,7 +150,7 @@ func getManifests(policyConf *types.PolicyConfig) ([][]map[string]interface{}, e
 // policyConf.ConsolidateManifests = false will generate a policy templates slice
 // that each template includes a single manifest specified in policyConf.
 // An error is returned if one or more manifests cannot be read or are invalid.
-func getPolicyTemplates(policyConf *types.PolicyConfig, ns string) ([]map[string]interface{}, error) {
+func getPolicyTemplates(policyConf *types.PolicyConfig) ([]map[string]interface{}, error) {
 	manifestGroups, err := getManifests(policyConf)
 	if err != nil {
 		return nil, err
@@ -258,13 +258,6 @@ func getPolicyTemplates(policyConf *types.PolicyConfig, ns string) ([]map[string
 		for i, tmpl := range policyTemplates {
 			if previousTemplate.Name != "" {
 				policyTemplates[i]["extraDependencies"] = []types.PolicyDependency{previousTemplate}
-			}
-
-			prevNS, found, err := unstructured.NestedString(tmpl, "objectDefinition", "metadata", "namespace")
-			if !found || err != nil {
-				previousTemplate.Namespace = ns
-			} else {
-				previousTemplate.Namespace = prevNS
 			}
 
 			// these fields are known to exist since the plugin created them

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -673,7 +673,7 @@ func TestIsPolicyTypeManifest(t *testing.T) {
 			wantVal: false,
 			wantErr: "invalid or not found apiVersion",
 		},
-		"missing name": {
+		"missing name in ConfigurationPolicy": {
 			manifest: map[string]interface{}{
 				"apiVersion": policyAPIVersion,
 				"kind":       "ConfigurationPolicy",
@@ -681,8 +681,19 @@ func TestIsPolicyTypeManifest(t *testing.T) {
 					"namespace": "foo",
 				},
 			},
-			wantVal: false,
+			wantVal: true,
 			wantErr: "invalid or not found metadata.name",
+		},
+		"missing name in non-policy": {
+			manifest: map[string]interface{}{
+				"apiVersion": "apps.open-cluster-management.io/v1",
+				"kind":       "PlacementRule",
+				"metadata": map[string]interface{}{
+					"name": "foo",
+				},
+			},
+			wantVal: false,
+			wantErr: "",
 		},
 	}
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -243,7 +243,7 @@ data:
 			Name:      "policy-app-config",
 		}
 
-		policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+		policyTemplates, err := getPolicyTemplates(&policyConf)
 		if err != nil {
 			t.Fatalf("Failed to get the policy templates: %v", err)
 		}
@@ -405,7 +405,7 @@ resources:
 			Name: "policy-kustomize",
 		}
 
-		policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+		policyTemplates, err := getPolicyTemplates(&policyConf)
 		if err != nil {
 			if test.ErrMsg != "" {
 				assertEqual(t, err.Error(), test.ErrMsg)
@@ -544,7 +544,7 @@ data:
 			Name:      "policy-app-config",
 		}
 
-		policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+		policyTemplates, err := getPolicyTemplates(&policyConf)
 		if err != nil {
 			t.Fatalf("Failed to get the policy templates: %v", err)
 		}
@@ -745,7 +745,7 @@ func TestGetPolicyTemplateFromPolicyTypeManifest(t *testing.T) {
 			},
 		}
 
-		policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+		policyTemplates, err := getPolicyTemplates(&policyConf)
 		if err != nil {
 			t.Fatalf("Failed to get the policy templates: %v", err)
 		}
@@ -818,7 +818,7 @@ data:
 		Name:      "policy-app-config",
 	}
 
-	policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+	policyTemplates, err := getPolicyTemplates(&policyConf)
 	if err != nil {
 		t.Fatalf("Failed to get the policy templates: %v", err)
 	}
@@ -906,7 +906,7 @@ data:
 		Name:      "policy-app-config",
 	}
 
-	policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+	policyTemplates, err := getPolicyTemplates(&policyConf)
 	if err != nil {
 		t.Fatalf("Failed to get the policy templates: %v ", err)
 	}
@@ -1015,7 +1015,7 @@ data:
 		Name:      "policy-app-config",
 	}
 
-	_, err = getPolicyTemplates(&policyConf, "default")
+	_, err = getPolicyTemplates(&policyConf)
 	assertEqual(t, err != nil, true)
 }
 
@@ -1047,7 +1047,7 @@ metadata:
 		Name:      "policy-kyverno-config",
 	}
 
-	policyTemplates, err := getPolicyTemplates(&policyConf, "default")
+	policyTemplates, err := getPolicyTemplates(&policyConf)
 	if err != nil {
 		t.Fatalf("Failed to get the policy templates: %v", err)
 	}
@@ -1104,7 +1104,7 @@ func TestGetPolicyTemplateNoManifests(t *testing.T) {
 		Name:      "policy-app-config",
 	}
 
-	_, err := getPolicyTemplates(&policyConf, "default")
+	_, err := getPolicyTemplates(&policyConf)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -1132,7 +1132,7 @@ func TestGetPolicyTemplateInvalidPath(t *testing.T) {
 		Name: "policy-app-config",
 	}
 
-	_, err := getPolicyTemplates(&policyConf, "default")
+	_, err := getPolicyTemplates(&policyConf)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -1161,7 +1161,7 @@ func TestGetPolicyTemplateInvalidManifest(t *testing.T) {
 		Name:      "policy-app-config",
 	}
 
-	_, err = getPolicyTemplates(&policyConf, "default")
+	_, err = getPolicyTemplates(&policyConf)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}


### PR DESCRIPTION
Some fixes to the policy ordering feature after an end-to-end demo exposed some problems. More details in each commit.