### PR TITLE
Allow placement generation to be shut off

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -152,6 +152,10 @@ policyDefaults:
   # generated for the policy since one is generated for the set. Set policies[*].generatePlacementWhenInSet 
   # or policyDefaults.generatePlacementWhenInSet to override.
   policySets: []
+  # Optional. Whether to generate placement manifests for policies. Placement generation occurs except when policies are
+  # part of a policy set. Use this setting to turn off placement generation for policies not in policy sets. This
+  # defaults to "true".
+  generatePolicyPlacement: true
   # Optional. When a policy is part of a policy set, by default the generator will not generate the placement
   # for this policy since a placement is generated for the policy set. If a placement should still be generated, 
   # set it to "true" so that the policy will be deployed with both policy placement and policy set placement. 

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -379,6 +379,74 @@ policies:
 	assertEqual(t, err.Error(), expected)
 }
 
+func TestConfigDefaultPlacementWithDisabledPlacement(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+  generatePolicyPlacement: false
+  placement:
+    clusterSelectors:
+      cloud: red hat
+policies:
+- name: policy-app-config
+  manifests:
+    - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policyDefaults must not specify " +
+		"a placement when generatePlacement is set to false"
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigPlacementWithDisabledPlacement(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	config := fmt.Sprintf(`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: my-policies
+  placement:
+    clusterSelectors:
+      cloud: red hat
+policies:
+- name: policy-app-config
+  generatePolicyPlacement: false
+  manifests:
+    - path: %s
+`,
+		path.Join(tmpDir, "configmap.yaml"),
+	)
+	p := Plugin{}
+
+	err := p.Config([]byte(config), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policy policy-app-config must not specify " +
+		"a placement when generatePlacement is set to false"
+	assertEqual(t, err.Error(), expected)
+}
+
 func TestConfigMultiplePlacementsClusterSelectorAndPlRPath(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,6 +20,7 @@ type PolicyOptions struct {
 	IgnorePending                  bool               `json:"ignorePending,omitempty" yaml:"ignorePending,omitempty"`
 	InformGatekeeperPolicies       bool               `json:"informGatekeeperPolicies,omitempty" yaml:"informGatekeeperPolicies,omitempty"`
 	InformKyvernoPolicies          bool               `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	GeneratePolicyPlacement        bool               `json:"generatePolicyPlacement,omitempty" yaml:"generatePolicyPlacement,omitempty"`
 	GeneratePlacementWhenInSet     bool               `json:"generatePlacementWhenInSet,omitempty" yaml:"generatePlacementWhenInSet,omitempty"`
 	PolicySets                     []string           `json:"policySets,omitempty" yaml:"policySets,omitempty"`
 	PolicyAnnotations              map[string]string  `json:"policyAnnotations,omitempty" yaml:"policyAnnotations,omitempty"`


### PR DESCRIPTION
When Policies are generated separately from PolicySets, it may be desirable to only generate the Policies and not the placement manifests.

Closes #86 