### PR TITLE
Add support for generating placement with raw data

### DIFF
--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -108,11 +108,15 @@ policyDefaults:
   # Optional. The placement configuration for the policies. This defaults to a placement configuration that matches all
   # clusters.
   placement:
-    # To specify a placement rule, specify key:value pair cluster selectors. (See placementRulePath to specify an
-    # existing file instead.)
+    # Deprecated: use clusterSelector instead
+    # To specify a placement rule, specify key:value pair cluster selectors or the full YAML for the desired cluster
+    # selectors. (See placementRulePath to specify an existing file instead.)
     clusterSelectors: {}
-    # To specify a placement, specify key:value pair cluster label selectors. (See placementPath to specify an existing
-    # file instead.)
+    # To specify a placement rule, specify key:value pair cluster selectors or the full YAML for the desired cluster
+    # selectors. (See placementRulePath to specify an existing file instead.)
+    clusterSelector: {}
+    # To specify a placement, specify key:value pair cluster label selectors or the full YAML for the desired cluster
+    # label selectors. (See placementPath to specify an existing file instead.)
     labelSelector: {}
     # Optional. Specifying a name will consolidate placement rules that contain the same cluster selectors.
     name: ""

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -135,7 +135,7 @@ policies:
 	assertReflectEqual(
 		t,
 		p.PolicyDefaults.Placement.ClusterSelectors,
-		map[string]string{"cloud": "red hat"},
+		map[string]interface{}{"cloud": "red hat"},
 	)
 	assertEqual(t, len(p.PolicyDefaults.Placement.LabelSelector), 0)
 	assertEqual(t, p.PolicyDefaults.RemediationAction, "enforce")
@@ -162,7 +162,7 @@ policies:
 	assertReflectEqual(
 		t,
 		policy1.Placement.ClusterSelectors,
-		map[string]string{"cloud": "red hat"},
+		map[string]interface{}{"cloud": "red hat"},
 	)
 	assertEqual(t, policy1.RemediationAction, "inform")
 	assertEqual(t, policy1.Severity, "medium")
@@ -184,7 +184,7 @@ policies:
 	assertReflectEqual(
 		t,
 		policy2.Placement.ClusterSelectors,
-		map[string]string{"cloud": "weather"},
+		map[string]interface{}{"cloud": "weather"},
 	)
 	assertEqual(t, policy2.RemediationAction, "enforce")
 	assertEqual(t, policy2.Severity, "medium")
@@ -1240,7 +1240,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								Name:             "policyset-placement",
-								ClusterSelectors: map[string]string{"my": "app"},
+								ClusterSelectors: map[string]interface{}{"my": "app"},
 							},
 						},
 					},
@@ -1306,8 +1306,8 @@ func TestPolicySetConfig(t *testing.T) {
 						Name: "my-policyset",
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
-								LabelSelector:    map[string]string{"cloud": "red hat"},
-								ClusterSelectors: map[string]string{"cloud": "red hat"},
+								LabelSelector:    map[string]interface{}{"cloud": "red hat"},
+								ClusterSelectors: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1325,7 +1325,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementPath:    "../config/plc.yaml",
-								ClusterSelectors: map[string]string{"cloud": "red hat"},
+								ClusterSelectors: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1343,7 +1343,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementName:    "plexistingname",
-								ClusterSelectors: map[string]string{"cloud": "red hat"},
+								ClusterSelectors: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1361,7 +1361,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementPath: "../config/plc.yaml",
-								LabelSelector: map[string]string{"cloud": "red hat"},
+								LabelSelector: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1379,7 +1379,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementName: "plexistingname",
-								LabelSelector: map[string]string{"cloud": "red hat"},
+								LabelSelector: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1397,7 +1397,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementRulePath: "../config/plc.yaml",
-								ClusterSelectors:  map[string]string{"cloud": "red hat"},
+								ClusterSelectors:  map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1415,7 +1415,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementRuleName: "plrexistingname",
-								ClusterSelectors:  map[string]string{"cloud": "red hat"},
+								ClusterSelectors:  map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1433,7 +1433,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementRulePath: "../config/plc.yaml",
-								LabelSelector:     map[string]string{"cloud": "red hat"},
+								LabelSelector:     map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1451,7 +1451,7 @@ func TestPolicySetConfig(t *testing.T) {
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
 								PlacementRuleName: "plrexistingname",
-								LabelSelector:     map[string]string{"cloud": "red hat"},
+								LabelSelector:     map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1497,14 +1497,14 @@ func TestPolicySetConfig(t *testing.T) {
 			name: "Placement and PlacementRule can't be mixed",
 			setupFunc: func(p *Plugin) {
 				p.Policies[0].Placement = types.PlacementConfig{
-					LabelSelector: map[string]string{"cloud": "red hat"},
+					LabelSelector: map[string]interface{}{"cloud": "red hat"},
 				}
 				p.PolicySets = []types.PolicySetConfig{
 					{
 						Name: "my-policyset",
 						PolicySetOptions: types.PolicySetOptions{
 							Placement: types.PlacementConfig{
-								ClusterSelectors: map[string]string{"cloud": "red hat"},
+								ClusterSelectors: map[string]interface{}{"cloud": "red hat"},
 							},
 						},
 					},
@@ -1600,4 +1600,49 @@ policies:
 
 	disabledPolicy := p.Policies[1]
 	assertEqual(t, disabledPolicy.Disabled, true)
+}
+
+func TestConflictingPlacementSelectors(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	configMapPath := path.Join(tmpDir, "configmap.yaml")
+	policyNS := "my-policies"
+	policyName := "policy-app"
+	defaultsConfig := fmt.Sprintf(
+		`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: %s
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: cloud
+        operator: In
+        values:
+          - red hat
+          - hello
+      cloud: red hat
+      clusterID: 1234-5678
+policies:
+- name: %s
+  manifests:
+    - path: %s
+`,
+		policyNS, policyName, configMapPath,
+	)
+
+	p := Plugin{}
+
+	err := p.Config([]byte(defaultsConfig), tmpDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := "policyDefaults placement has invalid selectors: " +
+		"the input is not a valid label selector or key-value label matching map"
+	assertEqual(t, err.Error(), expected)
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -76,13 +76,14 @@ func (t NamespaceSelector) String() string {
 }
 
 type PlacementConfig struct {
-	ClusterSelectors  map[string]string `json:"clusterSelectors,omitempty" yaml:"clusterSelectors,omitempty"`
-	LabelSelector     map[string]string `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
-	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
-	PlacementPath     string            `json:"placementPath,omitempty" yaml:"placementPath,omitempty"`
-	PlacementRulePath string            `json:"placementRulePath,omitempty" yaml:"placementRulePath,omitempty"`
-	PlacementName     string            `json:"placementName,omitempty" yaml:"placementName,omitempty"`
-	PlacementRuleName string            `json:"placementRuleName,omitempty" yaml:"placementRuleName,omitempty"`
+	ClusterSelectors  map[string]interface{} `json:"clusterSelectors,omitempty" yaml:"clusterSelectors,omitempty"`
+	ClusterSelector   map[string]interface{} `json:"clusterSelector,omitempty" yaml:"clusterSelector,omitempty"`
+	LabelSelector     map[string]interface{} `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
+	Name              string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	PlacementPath     string                 `json:"placementPath,omitempty" yaml:"placementPath,omitempty"`
+	PlacementRulePath string                 `json:"placementRulePath,omitempty" yaml:"placementRulePath,omitempty"`
+	PlacementName     string                 `json:"placementName,omitempty" yaml:"placementName,omitempty"`
+	PlacementRuleName string                 `json:"placementRuleName,omitempty" yaml:"placementRuleName,omitempty"`
 }
 
 type EvaluationInterval struct {


### PR DESCRIPTION
Placements can now be generated by nesting a full labelSelector or clusterSelector YAML under the `placement` key, in addition to the legacy method of listing key/value pairs under `placement`. This allows users to specify multiple clusters in the values array of a placement or placementRule, and to use matchLabels instead of matchExpressions (only supported by placement).

Signed-off-by: Will Kutler <wkutler@redhat.com>