### PR TITLE
Bump `action-gh-release` version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           make build-release
 
       - name: Release
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Sync:
- https://github.com/open-cluster-management-io/policy-generator-plugin/pull/114

(cherry picked from commit af428c7a26f7dab641ea89aadcadaa955eda2624)

Closes #12 