### PR TITLE
Manual sync - Fix build `sh` error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,7 @@ build-binary:
 
 .PHONY: build-release
 build-release:
-	@if [[ $(shell git status --porcelain | wc -l) -gt 0 ]]; \
-		then \
+	@if [ $(shell git status --porcelain | wc -l) -gt 0 ]; then \
 			echo "There are local modifications in the repo" > /dev/stderr; \
 			exit 1; \
 	fi

--- a/cmd/PolicyGenerator/main.go
+++ b/cmd/PolicyGenerator/main.go
@@ -28,7 +28,7 @@ func main() {
 				Version = info.Main.Version
 			}
 
-			if Version == "" {
+			if Version == "" || Version == "(devel)" {
 				Version = "Unversioned binary"
 			}
 		}


### PR DESCRIPTION
Manual sync:
- https://github.com/open-cluster-management-io/policy-generator-plugin/pull/123

```
/bin/sh: 1: [[: not found
```

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>
(cherry picked from commit 36a630d91d22501719509f327724d37ec2213d93)

Closes #28 