### PR TITLE
[manual-sync] Bump actions/checkout from 4 to 5 in the github-actions group

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
     name: Linting
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0 # Fetch all history for all tags and branches
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Unit Tests
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0 # Fetch all history for all tags and branches
 


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [actions/checkout](https://github.com/actions/checkout).

Updates `actions/checkout` from 4 to 5
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4...v5)

---
updated-dependencies:
- dependency-name: actions/checkout
  dependency-version: '5'
  dependency-type: direct:production
  update-type: version-update:semver-major
  dependency-group: github-actions
...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 07fbd9819034ab7963f6d2684bde59d6a3b6b41b)
Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>

Manual cherry-pick of:
- https://github.com/open-cluster-management-io/policy-generator-plugin/pull/206

Closes #157