### PR TITLE
Bump the github-actions group with 2 updates

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
     


### PR DESCRIPTION
Bumps the github-actions group with 2 updates: [actions/setup-go](https://github.com/actions/setup-go) and [softprops/action-gh-release](https://github.com/softprops/action-gh-release).

Updates `actions/setup-go` from 6 to 7
- [Release notes](https://github.com/actions/setup-go/releases)
- [Commits](https://github.com/actions/setup-go/compare/v6...v7)

---
updated-dependencies:
- dependency-name: actions/setup-go dependency-version: '7' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions

(cherry picked from commit 2dbaccc8427e340d54ad9670441a16c0a4bbae52)

Closes https://github.com/stolostron/policy-generator-plugin/issues/241